### PR TITLE
Fall back to BuildInfo module version when ldflags unset

### DIFF
--- a/cmd/orc/main.go
+++ b/cmd/orc/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -30,8 +31,27 @@ var (
 	buildDate = "unknown"
 )
 
+// resolveVersion picks the version string. ldflags (`make build`, GoReleaser)
+// win when set; otherwise fall back to the module version Go embeds for a
+// `go install …@vX.Y.Z` build. biVersion is BuildInfo.Main.Version (or "").
+func resolveVersion(biVersion string) string {
+	if version != "dev" {
+		return version // ldflags set it explicitly
+	}
+	if biVersion != "" && biVersion != "(devel)" {
+		return biVersion
+	}
+	return version // "dev"
+}
+
 func versionString() string {
-	return fmt.Sprintf("%s (%s, built %s)", version, commit, buildDate)
+	v := version
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		v = resolveVersion(bi.Main.Version)
+	} else {
+		v = resolveVersion("")
+	}
+	return fmt.Sprintf("%s (%s, built %s)", v, commit, buildDate)
 }
 
 func main() {

--- a/cmd/orc/main_test.go
+++ b/cmd/orc/main_test.go
@@ -860,6 +860,33 @@ func TestVersionDefaults(t *testing.T) {
 	}
 }
 
+func TestVersionString_BuildInfoFallback(t *testing.T) {
+	origV, origC, origD := version, commit, buildDate
+	t.Cleanup(func() { version, commit, buildDate = origV, origC, origD })
+
+	// Simulate an unstamped (`go install`) build: ldflags did not run.
+	version, commit, buildDate = "dev", "none", "unknown"
+
+	// When BuildInfo carries a real module version, it should be used.
+	got := resolveVersion("v0.1.0")
+	if got != "v0.1.0" {
+		t.Errorf("resolveVersion(real) = %q, want %q", got, "v0.1.0")
+	}
+
+	// When BuildInfo has no usable version, fall back to the ldflags default.
+	for _, bad := range []string{"", "(devel)"} {
+		if got := resolveVersion(bad); got != "dev" {
+			t.Errorf("resolveVersion(%q) = %q, want ldflags default %q", bad, got, "dev")
+		}
+	}
+
+	// When ldflags DID set a version, BuildInfo is ignored entirely.
+	version = "v9.9.9"
+	if got := resolveVersion("v0.1.0"); got != "v9.9.9" {
+		t.Errorf("resolveVersion with ldflags set = %q, want %q (ldflags wins)", got, "v9.9.9")
+	}
+}
+
 func TestRunCmd_NoDisambiguationHint_SingleArg(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".orc"), 0755); err != nil {


### PR DESCRIPTION
## Why

`make build` and GoReleaser stamp orc's version via `-ldflags`. But `go install github.com/jorge-barreto/orc/cmd/orc@vX.Y.Z` does a plain compile — no ldflags — so `orc --version` printed `dev (none, built unknown)` even when installed from a real tag. This is exactly how horde installs orc into its worker image, so a pinned `orc@v0.1.0` would still self-report `dev`.

Go automatically embeds the module version in `runtime/debug.BuildInfo.Main.Version` for a versioned install. This reads it as a fallback.

## What

- `versionString()` now consults `debug.ReadBuildInfo()`.
- New testable helper `resolveVersion(biVersion)`: ldflags win when set (`version != "dev"`); otherwise use the BuildInfo version if it's real (not `""`, not `"(devel)"`); otherwise `dev`.
- `make build` / GoReleaser are unaffected (they set `version` explicitly, so the fallback is skipped). Local `go build` still shows `dev` (BuildInfo is `(devel)`).

## Verification

- Unit test covers all four branches (real version, `""`, `"(devel)"`, ldflags-set).
- End-to-end: `go install …@<sha>` from this branch reports the embedded pseudo-version `v0.1.1-0.…-ecc47d2` — proving a tagged `@v0.1.1` install will report `v0.1.1`.

## Follow-up

After merge, tag **v0.1.1** so the fix lands in a release; horde's worker-image pin will target `@v0.1.1` (and `orc --version` in the image will then report `v0.1.1`).