### PR TITLE
eval: held-out grader, clean stage, separable grading (--regrade)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ go test ./internal/runner/ -count=1
 
 ## Architecture
 
-Five internal packages, each with a single responsibility:
+Core internal packages, each with a single responsibility:
 
 ```
 cmd/orc/main.go           CLI entrypoint (urfave/cli/v3)
@@ -31,8 +31,11 @@ internal/config/           Config + Phase structs, YAML loading, validation
 internal/state/            State persistence (JSON), timing, artifacts dir, atomic writes
 internal/dispatch/         Phase executors: script (bash), agent (claude -p), gate (human y/n); workflow/branch dispatched by runner
 internal/runner/           Main state machine loop — drives the workflow
+internal/eval/             Eval cases: stage builder (held-out grader), rubric grading, --regrade (see Eval Subsystem below)
 internal/ux/               ANSI-colored terminal output, phase headers, status rendering
 ```
+
+(Other packages — `docs`, `doctor`, `improve`, `report`, `scaffold`, `stats`, etc. — back individual subcommands.)
 
 **Data flow:** `main.go` loads config, creates state, builds a `Runner`, and calls `runner.Run()`. The runner iterates phases, calling `dispatch.Dispatch()` for each. Dispatch routes to `RunScript`, `RunAgent`, or `RunGate` based on phase type. `workflow` and `branch` phases are handled directly by the runner via inline child `Runner.Run()` calls. State is persisted to `.orc/artifacts/` after each phase.
 
@@ -53,6 +56,16 @@ The runner loop handles: condition checks (skip phase if shell command exits non
 ### Config Validation Rules
 
 Validation (`internal/config/validate.go`) enforces: unique phase names, `loop.goto` must reference an earlier phase, `parallel-with` must reference an existing phase, `parallel-with` and `loop` cannot be combined, agent phases need a `prompt` file that exists on disk, model must be `opus`/`sonnet`/`haiku`/empty, ticket patterns are anchored for full-match semantics, workflow/branch phases must reference existing workflows in `.orc/workflows/`, and cross-workflow circular references are detected via DFS at load time. The deprecated `on-fail` field is rejected with a migration hint.
+
+### Eval Subsystem
+
+`internal/eval/` (driven by `cmd/orc/eval.go`) measures workflow quality. Cases live in `.orc/evals/<case>/`: a `fixture.yaml` (with a **required `spec:` field** naming the agent-visible spec file), the spec file, `rubric.yaml`, and any held-out judge prompts / test scripts.
+
+**Held-out grader.** Before the workflow runs, `internal/eval/stage.go` creates a git worktree at the fixture `ref`, then makes ONE curation commit that copies the case spec to `.orc/eval-spec/spec.md`, removes the ENTIRE `.orc/evals/` dir (so the grader is never visible to the agent), writes the LIVE workflow/prompt files, and gitignores `.orc/artifacts/` and `.orc/audit/`. The worktree is thus git-clean (clean-tree guards pass). orc reads the rubric from the LIVE project at grade time, never from the worktree.
+
+**Eval-mode contract (opt-in).** orc sets `ORC_EVAL=1` and `ORC_SPEC_FILE=<abs path>`; a workflow whose ticket-fetch hits an external store can branch on these to read the local spec instead. orc neither requires nor enforces it — a self-contained workflow needs no change.
+
+**Re-grading.** `orc eval <case> --regrade` re-scores a SAVED run against the CURRENT rubric without re-running the workflow. `--regrade` is a BOOLEAN flag; the optional run-id is a SECOND positional argument (`orc eval <case> --regrade <run-id>`), never `--regrade=<id>`. History tracks two fingerprints — the workflow fingerprint (config + prompts) and a per-case rubric fingerprint — so `--report` distinguishes a score change from a workflow edit vs. a rubric edit.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You define your workflow as a series of **phases** in a YAML config file. Each p
 - **`orc debug`**: Analyze a phase execution — rendered prompt, tool call sequence, cost/token data, and exit status
 - **`orc doctor`**: AI-powered diagnostics for failed runs — gathers logs, timing, and feedback, then recommends next steps
 - **`orc improve`**: AI-assisted workflow refinement — one-shot or interactive editing of config and prompts
-- **`orc eval`**: Run eval cases against known scenarios to measure workflow quality, cost, and time — compare before and after workflow changes
+- **`orc eval`**: Run eval cases against known scenarios to measure workflow quality, cost, and time — compare before and after workflow changes, with a held-out grader the agent never sees
 - **`orc flow`**: Visualize the workflow as a rich flow diagram with loop regions, model badges, and hook annotations
 - **Prompt recipes**: `orc init --recipe` scaffolds from proven workflow patterns (simple, standard, full-pipeline, review-loop)
 
@@ -50,7 +50,7 @@ You define your workflow as a series of **phases** in a YAML config file. Each p
 - **Full audit trail**: Rendered prompts, agent logs, cost/token data, timing, and state all saved to `.orc/artifacts/`
 - **`orc report`**: Generate a run summary with timing, costs, phase outcomes, loop activity, and artifact listing — markdown or JSON
 - **`orc stats`**: Aggregate metrics across runs — success rate, cost/duration distributions, per-phase breakdown, failure categories, and weekly trends
-- **`orc eval`**: Measure workflow quality, cost, and time across eval cases pinned to known git refs — track score trends across config changes
+- **`orc eval`**: Measure workflow quality, cost, and time across eval cases pinned to known git refs — track score trends across config and rubric changes, and re-grade saved runs without re-running them
 - **Structured exit codes**: 0 (success), 1 (phase failure), 2 (timeout), 3 (config error), 4 (cost limit), 5 (interrupted), 6 (resume failure), 7 (infrastructure error), 8 (rate limit)
 
 ## Prerequisites
@@ -290,15 +290,23 @@ orc stats --json             # structured JSON output
 
 ### `orc eval [case]`
 
-Run eval cases to measure workflow quality. Each case is defined in `.orc/evals/<case>/` with a fixture (git ref + ticket) and rubric (scoring criteria). Runs the workflow in an isolated git worktree and evaluates results.
+Run eval cases to measure workflow quality. Each case is defined in `.orc/evals/<case>/` with a `fixture.yaml` (git ref + ticket + a required `spec:` field naming the agent-visible spec file) and a `rubric.yaml` (scoring criteria). orc replays the workflow in an isolated git worktree, then scores results against the rubric.
+
+The grader is **held out**: orc removes the entire `.orc/evals/` directory from the worktree before the workflow runs, so the agent never sees the rubric, judge prompts, or held-out tests — the grader is read from your live project at grade time only. As an opt-in convenience, orc exports `ORC_EVAL=1` and `ORC_SPEC_FILE=<abs path>` so a workflow that normally fetches a ticket from an external store can read the local spec instead (self-contained workflows need no change).
+
+Grading is separable: `--regrade` re-scores a saved run against the current rubric **without** re-running the workflow. It's a boolean flag — the optional run-id is a second positional argument.
 
 ```bash
 orc eval                     # run all eval cases
 orc eval bug-fix             # run a specific case
-orc eval --report            # show score history across runs
+orc eval bug-fix --regrade            # re-grade the latest saved run (no workflow re-run)
+orc eval bug-fix --regrade <run-id>   # re-grade a specific saved run
+orc eval --report            # show score history (workflow + rubric fingerprints)
 orc eval --list              # list available eval cases
 orc eval --json              # structured JSON output
 ```
+
+See `orc docs eval` for the full reference — fixture/rubric schema, judge criteria, the eval-mode contract, and fingerprinting.
 
 ### `orc doctor <ticket>`
 

--- a/cmd/orc/eval.go
+++ b/cmd/orc/eval.go
@@ -18,12 +18,13 @@ func evalCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "eval",
 		Usage:     "Run eval cases to measure workflow quality",
-		ArgsUsage: "[case]",
-		UsageText: "orc eval\n   orc eval bug-fix\n   orc eval --report\n   orc eval --list\n   orc eval --json",
+		ArgsUsage: "[case] [run-id]",
+		UsageText: "orc eval\n   orc eval bug-fix\n   orc eval bug-fix --regrade\n   orc eval bug-fix --regrade <run-id>\n   orc eval --report\n   orc eval --list\n   orc eval --json",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "report", Usage: "Show score history across runs"},
 			&cli.BoolFlag{Name: "list", Usage: "List available eval cases"},
 			&cli.BoolFlag{Name: "json", Usage: "Output as structured JSON"},
+			&cli.BoolFlag{Name: "regrade", Usage: "Re-grade a saved run against the current rubric without re-running; pass an optional run id as a second argument (defaults to the latest run)"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfgErr := func(err error) error {
@@ -83,6 +84,22 @@ func evalCmd() *cli.Command {
 				if caseName != filepath.Base(caseName) || caseName == ".." || caseName == "." {
 					return cfgErr(fmt.Errorf("invalid case name %q: must not contain path separators", caseName))
 				}
+			}
+
+			if cmd.Bool("regrade") {
+				if caseName == "" {
+					return cfgErr(fmt.Errorf("--regrade requires a case name: orc eval <case> --regrade [run-id]"))
+				}
+				runID := cmd.Args().Get(1)
+				fingerprint, cases, err := eval.RegradeEval(ctx, projectRoot, configPath, workflowName, cfg, caseName, runID)
+				if err != nil {
+					return fmt.Errorf("re-grading eval: %w", err)
+				}
+				if cmd.Bool("json") {
+					return eval.RenderJSON(os.Stdout, fingerprint, cases)
+				}
+				eval.RenderScoreReport(os.Stdout, fingerprint, cases)
+				return nil
 			}
 
 			fingerprint, cases, err := eval.RunEval(ctx, projectRoot, configPath, workflowName, cfg, caseName)

--- a/cmd/orc/eval.go
+++ b/cmd/orc/eval.go
@@ -43,6 +43,11 @@ func evalCmd() *cli.Command {
 			if cmd.Bool("list") && cmd.Bool("report") {
 				return cfgErr(fmt.Errorf("--list and --report are mutually exclusive"))
 			}
+			// --regrade with --list/--report would silently ignore the regrade
+			// (those flags early-return below). Reject so the contradiction is loud.
+			if cmd.Bool("regrade") && (cmd.Bool("list") || cmd.Bool("report")) {
+				return cfgErr(fmt.Errorf("--regrade cannot be combined with --list or --report"))
+			}
 
 			// --list and --report early-return BEFORE resolveWorkflow() —
 			// they are workflow-agnostic and must work in multi-workflow projects
@@ -91,9 +96,15 @@ func evalCmd() *cli.Command {
 					return cfgErr(fmt.Errorf("--regrade requires a case name: orc eval <case> --regrade [run-id]"))
 				}
 				runID := cmd.Args().Get(1)
+				if runID != "" && (runID != filepath.Base(runID) || runID == ".." || runID == ".") {
+					return cfgErr(fmt.Errorf("invalid run id %q: must not contain path separators", runID))
+				}
 				fingerprint, cases, err := eval.RegradeEval(ctx, projectRoot, configPath, workflowName, cfg, caseName, runID)
 				if err != nil {
-					return fmt.Errorf("re-grading eval: %w", err)
+					// RegradeEval failures are all config/setup errors (missing
+					// fixture/spec/rubric, no saved runs, run not found, invalid
+					// run id) — exit ExitConfigError (3) per the documented contract.
+					return cfgErr(fmt.Errorf("re-grading eval: %w", err))
 				}
 				if cmd.Bool("json") {
 					return eval.RenderJSON(os.Stdout, fingerprint, cases)

--- a/cmd/orc/eval_test.go
+++ b/cmd/orc/eval_test.go
@@ -3,11 +3,46 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jorge-barreto/orc/internal/runner"
 	cli "github.com/urfave/cli/v3"
 )
+
+// writeEvalProject sets up a minimal .orc project (config + one eval case) in a
+// temp dir and chdirs into it, so eval-command code that calls findProjectRoot
+// resolves it. Returns the project root.
+func writeEvalProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	must := func(path, content string) {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(filepath.Join(root, ".orc", "config.yaml"),
+		"phases:\n  - name: p\n    type: script\n    run: \"true\"\n")
+	must(filepath.Join(root, ".orc", "evals", "bug-fix", "fixture.yaml"),
+		"ref: HEAD\nticket: T-001\nspec: spec.md\n")
+	must(filepath.Join(root, ".orc", "evals", "bug-fix", "spec.md"), "do the thing\n")
+	must(filepath.Join(root, ".orc", "evals", "bug-fix", "rubric.yaml"),
+		"criteria:\n  - name: ok\n    check: \"exit 0\"\n    weight: 1\n")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(cwd) })
+	return root
+}
 
 func TestEvalCmd_CLAUDECODE_ExitConfigError(t *testing.T) {
 	t.Setenv("CLAUDECODE", "1")
@@ -18,6 +53,74 @@ func TestEvalCmd_CLAUDECODE_ExitConfigError(t *testing.T) {
 	err := app.Run(context.Background(), []string{"orc", "eval"})
 	if err == nil {
 		t.Fatal("expected error when CLAUDECODE is set")
+	}
+	var exitErr *runner.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *runner.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != runner.ExitConfigError {
+		t.Fatalf("expected exit code %d, got %d", runner.ExitConfigError, exitErr.Code)
+	}
+}
+
+// BLOCKING 3 + W2: an invalid (traversal) run id on --regrade must exit
+// ExitConfigError (3), not plain 1.
+func TestEvalCmd_RegradeInvalidRunID_ExitConfigError(t *testing.T) {
+	t.Setenv("CLAUDECODE", "")
+	writeEvalProject(t)
+	app := &cli.Command{
+		Name:     "orc",
+		Commands: []*cli.Command{evalCmd()},
+	}
+	err := app.Run(context.Background(),
+		[]string{"orc", "eval", "bug-fix", "../../etc/passwd", "--regrade"})
+	if err == nil {
+		t.Fatal("expected error for traversal run id")
+	}
+	var exitErr *runner.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *runner.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != runner.ExitConfigError {
+		t.Fatalf("expected exit code %d, got %d", runner.ExitConfigError, exitErr.Code)
+	}
+}
+
+// NOTE: --regrade combined with --list/--report is a contradiction (the latter
+// would silently win) → reject with ExitConfigError (3).
+func TestEvalCmd_RegradeWithList_ExitConfigError(t *testing.T) {
+	t.Setenv("CLAUDECODE", "")
+	writeEvalProject(t)
+	app := &cli.Command{
+		Name:     "orc",
+		Commands: []*cli.Command{evalCmd()},
+	}
+	err := app.Run(context.Background(),
+		[]string{"orc", "eval", "bug-fix", "--regrade", "--list"})
+	if err == nil {
+		t.Fatal("expected error for --regrade with --list")
+	}
+	var exitErr *runner.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *runner.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != runner.ExitConfigError {
+		t.Fatalf("expected exit code %d, got %d", runner.ExitConfigError, exitErr.Code)
+	}
+}
+
+// W2: a --regrade with no saved runs is a setup error → ExitConfigError (3).
+func TestEvalCmd_RegradeNoSavedRuns_ExitConfigError(t *testing.T) {
+	t.Setenv("CLAUDECODE", "")
+	writeEvalProject(t)
+	app := &cli.Command{
+		Name:     "orc",
+		Commands: []*cli.Command{evalCmd()},
+	}
+	err := app.Run(context.Background(),
+		[]string{"orc", "eval", "bug-fix", "--regrade"})
+	if err == nil {
+		t.Fatal("expected error when no saved runs exist")
 	}
 	var exitErr *runner.ExitError
 	if !errors.As(err, &exitErr) {

--- a/docs/superpowers/plans/2026-06-23-eval-redesign.md
+++ b/docs/superpowers/plans/2026-06-23-eval-redesign.md
@@ -1,0 +1,1350 @@
+# orc eval redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `orc eval` produce a trustworthy quality signal by running the live workflow against a clean, grader-free git stage, holding the grader out of the agent's environment, and grading as a separate re-runnable step.
+
+**Architecture:** The agent's stage becomes a `git worktree add <ref>` plus one *curation commit* (copy the case spec to a known path, `rm -rf .orc/evals/`, write live workflow/prompt files, `.gitignore` orc's runtime dirs, then commit) — so the tree is git-clean and the grader is physically absent. The grader (rubric + checks + judge prompts + fixture vars) is read from the *live* project at grade time, never from the worktree. Because grading is a pure function of `(artifacts, grader)`, a new `--regrade` path re-scores a saved run without re-running the workflow.
+
+**Tech Stack:** Go 1.22+, stdlib + `gopkg.in/yaml.v3` + `github.com/urfave/cli/v3`. Package under test: `internal/eval/`. CLI: `cmd/orc/eval.go`.
+
+## Global Constraints
+
+- Go 1.22+; tabs for indentation, never spaces (a PostToolUse hook runs `gofmt -w`, but write gofmt-correct Go from the start).
+- Dependencies limited to stdlib, `gopkg.in/yaml.v3`, `github.com/urfave/cli/v3`, `github.com/google/uuid`. Do not add new dependencies.
+- Errors wrapped with `%w`; all error strings for this package are prefixed `eval: `.
+- State files written atomically via `state.WriteFileAtomic`.
+- Subprocesses use `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}`, `cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }`, `cmd.WaitDelay = 5 * time.Second` (match existing `eval.go`/`rubric.go`).
+- Test command for one package: `go test ./internal/eval/ -count=1`. Single test: `go test ./internal/eval/ -run TestName -count=1`. Build: `make build`.
+- `spec:` is a **required** fixture field (hard migration — no fallback to "spec lives in the ref").
+- The `$ORC_EVAL`/`$ORC_SPEC_FILE` contract is **opt-in QOL** for the workflow; orc neither enforces nor needs it.
+- Grader path-resolution base (decided): all grader paths (`check:` relative paths, judge `prompt:`) resolve from the **live project root**; grader subprocesses run with `cmd.Dir = projectRoot`.
+- Spec stage path (decided): `.orc/eval-spec/spec.md` inside the worktree; `$ORC_SPEC_FILE` is its absolute path.
+- Re-grade history (decided): **append** a new row (never replace); mark it with `regraded_from: <run-id>`.
+
+---
+
+## File Structure
+
+- `internal/eval/eval.go` — Fixture struct (+ `Spec` field), loaders, fingerprints (workflow + rubric), worktree/stage build, `RunWorkflow`, history, `RunEval`, new `RegradeEval`.
+- `internal/eval/stage.go` *(new)* — stage construction: `BuildStage` (worktree + curation commit). Extracts the stage-building responsibility out of the `copyOrcDir`/`CreateWorktree` pair so it has one clear home and is unit-testable.
+- `internal/eval/rubric.go` — `EvaluateRubric` (+ fixture vars in env, live-project cwd), `ComputeScore`, expect helpers. Signature of `EvaluateRubric` changes to accept fixture vars and resolve from project root.
+- `internal/eval/render.go` — report/JSON rendering; history report gains the rubric-fingerprint column and a re-grade marker.
+- `cmd/orc/eval.go` — new `--regrade` flag and wiring.
+- `internal/eval/eval_test.go`, `internal/eval/stage_test.go` *(new)*, `internal/eval/rubric_test.go` — tests.
+- `internal/docs/content.go` — eval doc section updates (spec field, $ORC_SPEC_FILE contract, --regrade, two fingerprints).
+
+---
+
+## Task 1: Add required `spec:` field to Fixture
+
+**Files:**
+- Modify: `internal/eval/eval.go` (Fixture struct ~line 28; LoadFixture ~line 66)
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Produces: `Fixture.Spec string` (yaml `spec`); `LoadFixture` errors `eval: fixture.yaml: spec is required` when empty and `eval: fixture.yaml: spec %q must not contain path separators` when not a base name.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestLoadFixture_Spec(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"),
+		"ref: abc123\nticket: T-001\nspec: spec.md\n")
+	f, err := LoadFixture(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Spec != "spec.md" {
+		t.Errorf("Spec = %q, want spec.md", f.Spec)
+	}
+}
+
+func TestLoadFixture_MissingSpec(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"), "ref: abc123\nticket: T-001\n")
+	_, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatal("expected error for missing spec")
+	}
+	if !strings.Contains(err.Error(), "spec is required") {
+		t.Errorf("error = %v, want message containing 'spec is required'", err)
+	}
+}
+
+func TestLoadFixture_SpecPathSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"),
+		"ref: abc123\nticket: T-001\nspec: \"sub/spec.md\"\n")
+	_, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatal("expected error for spec with path separator")
+	}
+	if !strings.Contains(err.Error(), "must not contain path separators") {
+		t.Errorf("error = %v, want message containing 'must not contain path separators'", err)
+	}
+}
+```
+
+Also update the *existing* tests that build a fixture without `spec:` so they keep passing. Add `spec: spec.md` to the fixture YAML in: `TestLoadFixture`, `TestValidateRef` (both valid and invalid blocks), and `TestRenderCaseList` (both cases). For `TestLoadFixture_MissingRef`/`MissingTicket`/`InvalidRef`/`DotDotTicket`/`DotTicket`/`PathSeparatorTicket`/`StrictYAML`/`VarShadows*` leave them as-is (they assert a *different* earlier error, or assert on ref/ticket which are validated before spec — keep spec-validation ordered AFTER ticket validation, see Step 3).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run TestLoadFixture_Spec -count=1`
+Expected: FAIL — `f.Spec` undefined (compile error) then assertion failures.
+
+- [ ] **Step 3: Implement**
+
+In `internal/eval/eval.go`, add to the `Fixture` struct:
+
+```go
+type Fixture struct {
+	Ref         string            `yaml:"ref"`
+	Ticket      string            `yaml:"ticket"`
+	Spec        string            `yaml:"spec"`
+	Vars        map[string]string `yaml:"vars"`
+	Description string            `yaml:"description"`
+}
+```
+
+In `LoadFixture`, AFTER the existing ticket path-separator check (after `eval.go:89`) and BEFORE the ref regex check, add:
+
+```go
+	if f.Spec == "" {
+		return nil, fmt.Errorf("eval: fixture.yaml: spec is required")
+	}
+	if f.Spec != filepath.Base(f.Spec) {
+		return nil, fmt.Errorf("eval: fixture.yaml: spec %q must not contain path separators", f.Spec)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -count=1`
+Expected: PASS (all eval tests, including the updated existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/eval/eval.go internal/eval/eval_test.go
+git commit -m "eval: add required spec field to fixture"
+```
+
+---
+
+## Task 2: Stage builder — worktree + curation commit
+
+**Files:**
+- Create: `internal/eval/stage.go`
+- Create: `internal/eval/stage_test.go`
+- Modify: `internal/eval/eval.go` (these tests require `git`; the new code reuses `CreateWorktree`/`RemoveWorktree`)
+
+**Interfaces:**
+- Consumes: `CreateWorktree(ctx, projectRoot, ref, caseName) (string, error)` and `RemoveWorktree(projectRoot, worktreePath) error` (existing, `eval.go`); `Fixture` (Task 1); `*config.Config`.
+- Produces: `BuildStage(ctx, projectRoot, worktreePath, configPath string, cfg *config.Config, fixture *Fixture, caseName string) (specPathAbs string, err error)`. It (a) copies `<caseDir>/<spec>` to `<worktree>/.orc/eval-spec/spec.md`, (b) removes `<worktree>/.orc/evals`, (c) writes live workflow + prompt files (reusing `copyOrcDir`), (d) appends `.orc/artifacts/` and `.orc/audit/` to `<worktree>/.gitignore`, (e) `git add -A && git commit`. Returns the absolute path of the spec on the stage. Also produces the constant `SpecStagePath = ".orc/eval-spec/spec.md"`.
+- Produces: `caseDirFor(projectRoot, caseName string) string` helper. (Named `caseDirFor`, not `caseDir`, to avoid colliding with the existing local variable `caseDir` inside `runCase`.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/eval/stage_test.go`:
+
+```go
+package eval
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jorge-barreto/orc/internal/config"
+)
+
+// initGitRepo creates a git repo at dir with one commit and returns nothing.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func gitCommitAll(t *testing.T, dir, msg string) string {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", msg}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitStatusPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	return string(out)
+}
+
+func TestBuildStage(t *testing.T) {
+	repo := t.TempDir()
+	initGitRepo(t, repo)
+
+	// Project files at the ref: a workflow config, a prompt, an eval case (with grader).
+	writeFile(t, filepath.Join(repo, ".orc", "config.yaml"),
+		"phases:\n  - name: p\n    prompt: .orc/prompts/p.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "prompts", "p.md"), "REF VERSION")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "fixture.yaml"),
+		"ref: HEAD\nticket: T-1\nspec: spec.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "spec.md"), "BUILD THE THING")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "rubric.yaml"),
+		"criteria:\n  - name: c\n    check: \"exit 0\"\n    weight: 1\n")
+	ref := gitCommitAll(t, repo, "init")
+
+	// Live edit: the prompt differs from the committed ref version (this is what
+	// today's injection makes "dirty"; the curation commit must absorb it).
+	writeFile(t, filepath.Join(repo, ".orc", "prompts", "p.md"), "LIVE VERSION")
+
+	cfg := &config.Config{Phases: []config.Phase{{Name: "p", Prompt: ".orc/prompts/p.md"}}}
+	fixture := &Fixture{Ref: ref, Ticket: "T-1", Spec: "spec.md"}
+
+	wt, err := CreateWorktree(context.Background(), repo, ref, "bug-fix")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	defer RemoveWorktree(repo, wt)
+
+	specAbs, err := BuildStage(context.Background(), repo, wt,
+		filepath.Join(repo, ".orc", "config.yaml"), cfg, fixture)
+	if err != nil {
+		t.Fatalf("BuildStage: %v", err)
+	}
+
+	// (1) tree is clean
+	if s := gitStatusPorcelain(t, wt); s != "" {
+		t.Errorf("worktree not clean after BuildStage:\n%s", s)
+	}
+	// (2) grader/evals dir is gone
+	if _, err := os.Stat(filepath.Join(wt, ".orc", "evals")); !os.IsNotExist(err) {
+		t.Errorf(".orc/evals should be absent from stage, stat err = %v", err)
+	}
+	// (3) spec copied to the known path; returned path matches; contents correct
+	wantSpec := filepath.Join(wt, SpecStagePath)
+	if specAbs != wantSpec {
+		t.Errorf("specAbs = %q, want %q", specAbs, wantSpec)
+	}
+	data, err := os.ReadFile(specAbs)
+	if err != nil || string(data) != "BUILD THE THING" {
+		t.Errorf("spec contents = %q (err %v), want 'BUILD THE THING'", data, err)
+	}
+	// (4) live prompt present (not the ref version)
+	pd, _ := os.ReadFile(filepath.Join(wt, ".orc", "prompts", "p.md"))
+	if string(pd) != "LIVE VERSION" {
+		t.Errorf("prompt = %q, want LIVE VERSION", pd)
+	}
+	// (5) artifacts/audit are gitignored: creating them keeps the tree clean
+	writeFile(t, filepath.Join(wt, ".orc", "artifacts", "x"), "y")
+	writeFile(t, filepath.Join(wt, ".orc", "audit", "z"), "w")
+	if s := gitStatusPorcelain(t, wt); s != "" {
+		t.Errorf("artifacts/audit should be gitignored, got dirty:\n%s", s)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run TestBuildStage -count=1`
+Expected: FAIL — `BuildStage` and `SpecStagePath` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/eval/stage.go`:
+
+```go
+package eval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/jorge-barreto/orc/internal/config"
+)
+
+// SpecStagePath is the worktree-relative path where the case spec is written.
+// The workflow finds it via $ORC_SPEC_FILE (its absolute form).
+const SpecStagePath = ".orc/eval-spec/spec.md"
+
+// caseDirFor returns the eval case directory for a given case name.
+// Named caseDirFor (not caseDir) to avoid colliding with the local
+// variable `caseDir` inside runCase.
+func caseDirFor(projectRoot, caseName string) string {
+	return filepath.Join(projectRoot, ".orc", "evals", caseName)
+}
+
+// BuildStage curates an existing worktree (already checked out at fixture.Ref)
+// into the agent's stage and commits it so the tree is git-clean:
+//   - copies the case spec to SpecStagePath,
+//   - removes .orc/evals (holds the grader out of the agent's environment),
+//   - writes the live workflow + prompt files over the ref's copies,
+//   - gitignores orc's runtime dirs so the run doesn't re-dirty the tree,
+//   - commits everything.
+// Returns the absolute path of the spec on the stage.
+func BuildStage(ctx context.Context, projectRoot, worktreePath, configPath string, cfg *config.Config, fixture *Fixture, caseName string) (string, error) {
+	// (a) copy the spec onto the stage
+	specSrc := filepath.Join(caseDirFor(projectRoot, caseName), fixture.Spec)
+	specDst := filepath.Join(worktreePath, SpecStagePath)
+	if err := os.MkdirAll(filepath.Dir(specDst), 0o755); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: creating eval-spec dir: %w", err)
+	}
+	if err := copyFile(specSrc, specDst); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: copying spec: %w", err)
+	}
+
+	// (b) remove .orc/evals — the grader must not be on the agent's stage
+	if err := os.RemoveAll(filepath.Join(worktreePath, ".orc", "evals")); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: removing .orc/evals: %w", err)
+	}
+
+	// (c) write the live workflow + prompt files over the ref's copies
+	if err := copyOrcDir(projectRoot, worktreePath, configPath, cfg); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: writing live workflow: %w", err)
+	}
+
+	// (d) gitignore orc's runtime dirs so the run stays clean
+	if err := appendGitignore(worktreePath, ".orc/artifacts/", ".orc/audit/"); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: writing .gitignore: %w", err)
+	}
+
+	// (e) commit the curated stage
+	if err := gitCommitStage(ctx, worktreePath); err != nil {
+		return "", err
+	}
+	return specDst, nil
+}
+
+// appendGitignore appends entries to the worktree's root .gitignore, creating it
+// if absent and avoiding duplicate lines.
+func appendGitignore(worktreePath string, entries ...string) error {
+	path := filepath.Join(worktreePath, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	have := map[string]bool{}
+	for _, line := range splitLines(string(existing)) {
+		have[line] = true
+	}
+	out := string(existing)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out += "\n"
+	}
+	for _, e := range entries {
+		if !have[e] {
+			out += e + "\n"
+		}
+	}
+	return os.WriteFile(path, []byte(out), 0o644)
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// gitCommitStage runs `git add -A && git commit` in the worktree with an
+// identity that does not depend on the user's git config.
+func gitCommitStage(ctx context.Context, worktreePath string) error {
+	add := exec.CommandContext(ctx, "git", "add", "-A")
+	add.Dir = worktreePath
+	setProcAttrs(add)
+	if out, err := add.CombinedOutput(); err != nil {
+		return fmt.Errorf("eval: BuildStage: git add: %w\n%s", err, out)
+	}
+	commit := exec.CommandContext(ctx, "git",
+		"-c", "user.email=orc-eval@localhost",
+		"-c", "user.name=orc eval",
+		"-c", "commit.gpgsign=false",
+		"commit", "-q", "-m", "orc eval stage",
+	)
+	commit.Dir = worktreePath
+	setProcAttrs(commit)
+	if out, err := commit.CombinedOutput(); err != nil {
+		return fmt.Errorf("eval: BuildStage: git commit: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// setProcAttrs applies the standard process-group settings used across eval.
+func setProcAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
+	cmd.WaitDelay = 5 * time.Second
+}
+
+var _ = config.Config{} // keep config import if cfg type referenced only in signature
+```
+
+Note: the test in Step 1 already calls `BuildStage(context.Background(), repo, wt, filepath.Join(repo, ".orc", "config.yaml"), cfg, fixture)` — that is 6 args, but the signature has 7 (trailing `caseName`). Before running, append `"bug-fix"` as the final argument to that call so it reads `BuildStage(..., cfg, fixture, "bug-fix")`.
+
+Delete the `var _ = config.Config{}` line shown above — `config` is already referenced by the `cfg *config.Config` parameter, so the import is used; the line is only an explanatory guard, not real code.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -run TestBuildStage -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full package and commit**
+
+Run: `go test ./internal/eval/ -count=1`
+Expected: PASS.
+
+```bash
+git add internal/eval/stage.go internal/eval/stage_test.go
+git commit -m "eval: add BuildStage — clean, grader-free curation commit"
+```
+
+---
+
+## Task 3: Wire fixture vars + live-project cwd into rubric grading
+
+**Files:**
+- Modify: `internal/eval/rubric.go` (`EvaluateRubric` ~line 65; `filteredEnv` ~line 43)
+- Modify: `internal/eval/eval.go` (the `EvaluateRubric` call in `runCase` ~line 489)
+- Test: `internal/eval/rubric_test.go`
+
+**Interfaces:**
+- Consumes: `dispatch.ExpandConfigVars` is NOT used here (fixture vars are a plain map already); instead expand var-in-var with `dispatch.ExpandVars`.
+- Produces: new signature `EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, projectRoot string, vars map[string]string) ([]CriterionResult, error)`. The `worktreePath` parameter is **removed** — grader subprocesses now run with `cmd.Dir = projectRoot` and resolve paths from the live project. Fixture `vars` are expanded (var-in-var) and injected into both `check:` and judge subprocess envs as bare `KEY` and `ORC_KEY`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/rubric_test.go` (create the file's package header if the file does not yet exist — it does):
+
+```go
+func TestEvaluateRubric_CheckSeesVars(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "uses-var", Check: `test "$MYVAR" = "hello"`, Expect: "exit 0", Weight: 1},
+	}}
+	vars := map[string]string{"MYVAR": "hello"}
+
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || !results[0].Pass {
+		t.Errorf("check should see MYVAR=hello and pass; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_CheckSeesORCPrefixedVar(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "orc-prefixed", Check: `test "$ORC_MYVAR" = "hi"`, Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot,
+		map[string]string{"MYVAR": "hi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("check should see ORC_MYVAR=hi; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_VarInVarExpansion(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	// SECOND references FIRST; it must arrive expanded.
+	vars := expandFixtureVars(map[string]string{
+		"FIRST":  "/base",
+		"SECOND": "$FIRST/leaf",
+	}, []string{"FIRST", "SECOND"})
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "expanded", Check: `test "$SECOND" = "/base/leaf"`, Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("SECOND should expand to /base/leaf; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_CheckRunsFromProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, "marker.txt"), "x")
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "cwd", Check: "test -f marker.txt", Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("check should run with cwd=projectRoot; got %+v", results)
+	}
+}
+```
+
+Note `expandFixtureVars(vars map[string]string, order []string) map[string]string` is a new helper defined in Step 3. Because Go maps have no order and fixture YAML var ordering isn't preserved by `map[string]string`, the helper takes an explicit key order. For the test we pass the order directly; for production, see the caveat in Step 3.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run TestEvaluateRubric -count=1`
+Expected: FAIL — new `EvaluateRubric` signature / `expandFixtureVars` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `internal/eval/rubric.go`, change `EvaluateRubric`'s signature and the two subprocess env constructions. Replace the function header and both `cmd.Dir`/`cmd.Env` lines:
+
+```go
+// EvaluateRubric runs all criteria against the run's artifacts. Grader
+// subprocesses run with cwd = projectRoot and receive the fixture vars
+// (as KEY and ORC_KEY); paths resolve from the live project.
+func EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, projectRoot string, vars map[string]string) ([]CriterionResult, error) {
+	varEnv := make([]string, 0, len(vars)*2)
+	for k, v := range vars {
+		varEnv = append(varEnv, k+"="+v, "ORC_"+k+"="+v)
+	}
+	baseExtras := append([]string{
+		"ARTIFACTS_DIR=" + artifactsDir,
+		"WORK_DIR=" + projectRoot,
+		"PROJECT_ROOT=" + projectRoot,
+	}, varEnv...)
+	...
+}
+```
+
+Then in the `c.Check != ""` branch, replace:
+
+```go
+			cmd.Dir = worktreePath
+			cmd.Env = filteredEnv("ARTIFACTS_DIR="+artifactsDir, "WORK_DIR="+worktreePath, "PROJECT_ROOT="+projectRoot)
+```
+
+with:
+
+```go
+			cmd.Dir = projectRoot
+			cmd.Env = filteredEnv(baseExtras...)
+```
+
+And in the `c.Judge` branch, replace the same two lines (currently using `worktreePath`) with:
+
+```go
+			cmd.Dir = projectRoot
+			cmd.Env = filteredEnv(baseExtras...)
+```
+
+Add the `expandFixtureVars` helper to `internal/eval/rubric.go`:
+
+```go
+// expandFixtureVars expands var-in-var references in declaration order, so a
+// later var like "$FIRST/leaf" resolves against earlier vars. Order is the
+// fixture's var key order.
+func expandFixtureVars(vars map[string]string, order []string) map[string]string {
+	result := make(map[string]string, len(vars))
+	lookup := make(map[string]string, len(vars))
+	for _, k := range order {
+		v, ok := vars[k]
+		if !ok {
+			continue
+		}
+		expanded := dispatch.ExpandVars(v, lookup)
+		result[k] = expanded
+		lookup[k] = expanded
+	}
+	// Include any keys not present in order (defensive), unexpanded.
+	for k, v := range vars {
+		if _, done := result[k]; !done {
+			result[k] = v
+		}
+	}
+	return result
+}
+```
+
+`dispatch` is already imported in `rubric.go`. Remove the now-unused `overridden` entries referencing `WORK_DIR`/`PROJECT_ROOT`? No — leave `filteredEnv` as is; it correctly strips `ORC_*` and the overridable keys so our explicit `baseExtras` (which include `ORC_*` fixture vars) win by being appended last.
+
+**Caveat on var order (production):** `Fixture.Vars` is a `map[string]string`, which loses YAML order, so `expandFixtureVars` cannot know declaration order from it alone. Task 3 establishes the *mechanism and signature*; Task 4 supplies the order. For now, production callers (Task 4) will pass `sortedKeys(vars)` until/unless fixture vars are changed to an ordered type. Document this limitation in the doc task (Task 7): "var-in-var expansion in fixture vars resolves in alphabetical key order." Add helper:
+
+```go
+import "sort"
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+```
+
+(If `sort` is already imported in the file, don't re-import.)
+
+- [ ] **Step 4: Update the caller in eval.go so the package compiles**
+
+In `internal/eval/eval.go` `runCase` (~line 489), replace:
+
+```go
+	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, worktreePath, e.projectRoot)
+```
+
+with:
+
+```go
+	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
+	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, e.projectRoot, expandedVars)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/rubric.go internal/eval/eval.go internal/eval/rubric_test.go
+git commit -m "eval: grader checks see fixture vars; resolve from project root"
+```
+
+---
+
+## Task 4: Use BuildStage in runCase and set the eval-mode contract
+
+**Files:**
+- Modify: `internal/eval/eval.go` (`runCase` ~line 466; `RunWorkflow` ~line 334)
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Consumes: `BuildStage` (Task 2), `EvaluateRubric` new signature (Task 3).
+- Produces: `RunWorkflow` gains a `specFile string` parameter; it sets `ORC_EVAL=1` and `ORC_SPEC_FILE=<specFile>` in the child env (in addition to fixture vars). New signature: `RunWorkflow(ctx, worktreePath, ticket, workflowName, specFile string, vars map[string]string) (*RunResult, error)`. `runCase` calls `CreateWorktree` then `BuildStage` (replacing the bare `copyOrcDir` call) and threads the returned spec path into `RunWorkflow`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestRunWorkflow_SetsEvalEnv(t *testing.T) {
+	// We can't run a real `orc run` here, but we can assert the env-building
+	// helper sets ORC_EVAL and ORC_SPEC_FILE. Extracted as buildEvalEnv.
+	env := buildEvalEnv("/stage/.orc/eval-spec/spec.md", map[string]string{"K": "v"})
+	joined := strings.Join(env, "\n")
+	for _, want := range []string{
+		"ORC_EVAL=1",
+		"ORC_SPEC_FILE=/stage/.orc/eval-spec/spec.md",
+		"K=v",
+		"ORC_K=v",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("env missing %q", want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/eval/ -run TestRunWorkflow_SetsEvalEnv -count=1`
+Expected: FAIL — `buildEvalEnv` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `internal/eval/eval.go`, extract the env construction in `RunWorkflow` into a helper and add the eval-mode vars. Replace the inline env-building block (lines ~349–366) with a call to `buildEvalEnv`, and add the helper:
+
+```go
+// buildEvalEnv returns the child env for an eval run: inherited env minus
+// CLAUDECODE/ORC_*, plus fixture vars (KEY and ORC_KEY), plus the eval-mode
+// contract (ORC_EVAL, ORC_SPEC_FILE).
+func buildEvalEnv(specFile string, vars map[string]string) []string {
+	env := make([]string, 0, len(os.Environ())+len(vars)*2+2)
+	for _, kv := range os.Environ() {
+		idx := strings.IndexByte(kv, '=')
+		if idx < 0 {
+			continue
+		}
+		key := kv[:idx]
+		if strings.HasPrefix(key, "CLAUDECODE") || strings.HasPrefix(key, "ORC_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	for k, v := range vars {
+		env = append(env, k+"="+v, "ORC_"+k+"="+v)
+	}
+	env = append(env, "ORC_EVAL=1", "ORC_SPEC_FILE="+specFile)
+	return env
+}
+```
+
+Change `RunWorkflow`'s signature to accept `specFile`:
+
+```go
+func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName, specFile string, vars map[string]string) (*RunResult, error) {
+```
+
+and replace the env block with:
+
+```go
+	cmd.Env = buildEvalEnv(specFile, vars)
+```
+
+In `runCase`, replace the `copyOrcDir` + `RunWorkflow` calls:
+
+```go
+	specFile, err := BuildStage(ctx, e.projectRoot, worktreePath, e.configPath, e.cfg, fixture, caseName)
+	if err != nil {
+		return CaseResult{Name: caseName}, fmt.Errorf("eval: building stage for %q: %w", caseName, err)
+	}
+
+	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, specFile, fixture.Vars)
+```
+
+(Delete the old `copyOrcDir(...)` block in `runCase`. Keep `copyOrcDir` itself — `BuildStage` calls it.)
+
+Update the existing `TestRunWorkflow_FallbackToHistory` if it calls `RunWorkflow` directly — it does NOT (it only exercises state helpers), so no change needed there. Search for any other `RunWorkflow(` callers: only `runCase`. Good.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/eval/eval.go internal/eval/eval_test.go
+git commit -m "eval: runCase uses BuildStage; set ORC_EVAL/ORC_SPEC_FILE contract"
+```
+
+---
+
+## Task 5: Two fingerprints — add rubric fingerprint to history
+
+**Files:**
+- Modify: `internal/eval/eval.go` (`HistoryEntry` ~line 312, `ConfigFingerprint` ~line 167, `AppendResult` ~line 441, `runCase`/`RunEval`)
+- Modify: `internal/eval/render.go` (`RenderHistoryReport` ~line 66)
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Produces: `RubricFingerprint(rubric *Rubric, caseDir, projectRoot string) (string, error)` — hashes `rubric.yaml` content plus the contents of each judge `prompt:` file (resolved from projectRoot) plus each `check:` string, returning 8 hex chars. `HistoryEntry` gains `RubricFingerprints map[string]string json:"rubric_fingerprints"` (per-case, since each case has its own rubric). `CaseHistoryEntry` gains `RegradedFrom string json:"regraded_from,omitempty"`. `AppendResult` signature unchanged but reads a new `CaseResult.RubricFingerprint string` and `CaseResult.RegradedFrom string` field.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestRubricFingerprint_ChangesWithRubric(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	r1 := &Rubric{Criteria: []Criterion{{Name: "a", Check: "exit 0", Weight: 1}}}
+	fp1, err := RubricFingerprint(r1, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2 := &Rubric{Criteria: []Criterion{{Name: "a", Check: "exit 1", Weight: 1}}}
+	fp2, err := RubricFingerprint(r2, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Error("rubric fingerprint should change when a check changes")
+	}
+}
+
+func TestRubricFingerprint_ChangesWithJudgePrompt(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "v1")
+	r := &Rubric{Criteria: []Criterion{{Name: "q", Judge: true, Prompt: ".orc/p.md", Weight: 1}}}
+	fp1, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "v2")
+	fp2, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Error("rubric fingerprint should change when judge prompt content changes")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run TestRubricFingerprint -count=1`
+Expected: FAIL — `RubricFingerprint` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `internal/eval/eval.go`:
+
+```go
+// RubricFingerprint hashes the rubric's grading inputs: each check string and
+// the contents of each judge prompt file (resolved from projectRoot). Returns
+// 8 hex chars, stable and order-independent across criteria.
+func RubricFingerprint(rubric *Rubric, caseDir, projectRoot string) (string, error) {
+	h := sha256.New()
+	// Sort criteria by name for determinism.
+	names := make([]string, len(rubric.Criteria))
+	byName := make(map[string]Criterion, len(rubric.Criteria))
+	for i, c := range rubric.Criteria {
+		names[i] = c.Name
+		byName[c.Name] = c
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		c := byName[name]
+		fmt.Fprintf(h, "name:%s\nweight:%g\nexpect:%s\ncheck:%s\njudge:%t\n",
+			c.Name, c.Weight, c.Expect, c.Check, c.Judge)
+		if c.Judge && c.Prompt != "" {
+			data, err := os.ReadFile(filepath.Join(projectRoot, c.Prompt))
+			if err != nil {
+				return "", fmt.Errorf("eval: rubric fingerprint: reading %s: %w", c.Prompt, err)
+			}
+			fmt.Fprintf(h, "prompt:%s:", c.Prompt)
+			h.Write(data)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))[:8], nil
+}
+```
+
+Add fields. To `CaseResult` (in `rubric.go`):
+
+```go
+	RubricFingerprint string `json:"rubric_fingerprint,omitempty"`
+	RegradedFrom      string `json:"regraded_from,omitempty"`
+```
+
+To `HistoryEntry` (in `eval.go`), add a per-case rubric fingerprint map:
+
+```go
+	RubricFingerprints map[string]string `json:"rubric_fingerprints,omitempty"`
+```
+
+To `CaseHistoryEntry`:
+
+```go
+	RegradedFrom string `json:"regraded_from,omitempty"`
+```
+
+In `AppendResult`, populate them:
+
+```go
+func (h *History) AppendResult(fingerprint string, cases []CaseResult) {
+	entry := HistoryEntry{
+		Timestamp:          time.Now().UTC().Format(time.RFC3339),
+		ConfigFingerprint:  fingerprint,
+		Cases:              make(map[string]CaseHistoryEntry),
+		RubricFingerprints: make(map[string]string),
+	}
+	for _, c := range cases {
+		entry.Cases[c.Name] = CaseHistoryEntry{
+			Score:           c.Score,
+			CostUSD:         c.CostUSD,
+			DurationSeconds: c.DurationSeconds,
+			Details:         c.Details,
+			RegradedFrom:    c.RegradedFrom,
+		}
+		if c.RubricFingerprint != "" {
+			entry.RubricFingerprints[c.Name] = c.RubricFingerprint
+		}
+	}
+	h.Runs = append(h.Runs, entry)
+}
+```
+
+In `runCase`, compute and set the rubric fingerprint on the result:
+
+```go
+	rubricFP, _ := RubricFingerprint(rubric, caseDir, e.projectRoot)
+	result.RubricFingerprint = rubricFP
+```
+
+(Add this right before `return result, nil`. `caseDir` is the local var already computed at the top of `runCase`.)
+
+In `render.go` `RenderHistoryReport`, add a RUBRIC column. Change the header and row format:
+
+```go
+	fmt.Fprintf(w, "  %s%-12s %-10s %-13s %-10s %-11s %s%s\n",
+		ux.Dim, "FINGERPRINT", "RUBRIC", "DATE", "AVG SCORE", "TOTAL COST", "TOTAL TIME", ux.Reset)
+```
+
+and in the loop, derive a single rubric fingerprint string for the row (join distinct per-case values, or show the lone value):
+
+```go
+		rubricFP := summarizeRubricFPs(entry.RubricFingerprints)
+		...
+		fmt.Fprintf(w, "  %-12s %-10s %-13s %d/100      $%-10.2f %s\n",
+			entry.ConfigFingerprint, rubricFP, dateStr,
+			int(math.Round(avgScore)), totalCost, state.FormatDuration(totalDuration))
+```
+
+Add the helper to `render.go`:
+
+```go
+// summarizeRubricFPs renders the rubric fingerprints for a history row: the
+// single value if all cases share it, "-" if none, else "mixed".
+func summarizeRubricFPs(m map[string]string) string {
+	if len(m) == 0 {
+		return "-"
+	}
+	var first string
+	for _, v := range m {
+		if first == "" {
+			first = v
+		} else if v != first {
+			return "mixed"
+		}
+	}
+	return first
+}
+```
+
+- [ ] **Step 4: Update existing history/report tests**
+
+`TestRenderHistoryReport` asserts presence of `abc123`, `85/100`, `Jan 15` — still present. Add `"RUBRIC"` to its want-list to lock the new column header:
+
+```go
+	for _, want := range []string{"abc123", "85/100", "Jan 15", "RUBRIC"} {
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/eval.go internal/eval/rubric.go internal/eval/render.go internal/eval/eval_test.go
+git commit -m "eval: track rubric fingerprint per case in history + report"
+```
+
+---
+
+## Task 6: `--regrade` — re-score a saved run without re-running
+
+**Files:**
+- Modify: `internal/eval/eval.go` (add `RegradeEval`, a `regradeCase` helper on `evalRunner` or standalone)
+- Modify: `cmd/orc/eval.go` (add `--regrade` flag + wiring)
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Consumes: `state.ListHistory(artifactsDir) ([]state.HistoryEntry, error)`, `state.LatestHistoryDir`, `state.ArtifactsDirForWorkflow`, `EvaluateRubric` (Task 3), `RubricFingerprint` (Task 5), `ComputeScore`, `LoadFixture`, `LoadRubric`.
+- Produces: `RegradeEval(ctx context.Context, projectRoot, configPath, workflowName string, cfg *config.Config, caseName, runID string) (string, []CaseResult, error)`. Loads the saved run's artifacts dir (named `runID`, or the latest if `runID==""`), runs only the grade step against the *current* rubric, sets `CaseResult.RegradedFrom = <runID>`, appends a history row, returns results. `caseName` is required for regrade (can't regrade "all").
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestResolveRunArtifactsDir(t *testing.T) {
+	// Build an artifacts tree with two history runs; resolveRunArtifactsDir
+	// returns the named one, and the latest when runID is empty.
+	base := t.TempDir()
+	mk := func(runID string) {
+		d := filepath.Join(base, "history", runID)
+		writeFile(t, filepath.Join(d, "state.json"),
+			`{"ticket":"T-1","status":"completed","phases":{}}`)
+	}
+	mk("2026-01-01T10-00-00.000")
+	mk("2026-01-02T10-00-00.000")
+
+	got, err := resolveRunArtifactsDir(base, "2026-01-01T10-00-00.000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got) != "2026-01-01T10-00-00.000" {
+		t.Errorf("named run = %q, want the 01-01 dir", got)
+	}
+
+	latest, err := resolveRunArtifactsDir(base, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(latest) != "2026-01-02T10-00-00.000" {
+		t.Errorf("latest run = %q, want the 01-02 dir", latest)
+	}
+
+	_, err = resolveRunArtifactsDir(base, "nonexistent-run")
+	if err == nil {
+		t.Fatal("expected error for nonexistent run id")
+	}
+	if !strings.Contains(err.Error(), "run not found") {
+		t.Errorf("error = %v, want 'run not found'", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/eval/ -run TestResolveRunArtifactsDir -count=1`
+Expected: FAIL — `resolveRunArtifactsDir` undefined.
+
+- [ ] **Step 3: Implement the resolver and RegradeEval**
+
+Add to `internal/eval/eval.go`:
+
+```go
+// resolveRunArtifactsDir returns the artifacts dir for a saved run. If runID is
+// empty, returns the most recent history entry. Errors if the named run or any
+// history is absent.
+func resolveRunArtifactsDir(artifactsDir, runID string) (string, error) {
+	if runID == "" {
+		latest, err := state.LatestHistoryDir(artifactsDir)
+		if err != nil {
+			return "", fmt.Errorf("eval: locating latest run: %w", err)
+		}
+		if latest == "" {
+			return "", fmt.Errorf("eval: no saved runs found under %s", state.HistoryDir(artifactsDir))
+		}
+		return latest, nil
+	}
+	dir := filepath.Join(state.HistoryDir(artifactsDir), runID)
+	if !state.HasState(dir) {
+		return "", fmt.Errorf("eval: run not found: %q under %s", runID, state.HistoryDir(artifactsDir))
+	}
+	return dir, nil
+}
+
+// RegradeEval re-scores a saved run's artifacts against the current rubric,
+// without re-running the workflow. Appends a history row marked RegradedFrom.
+func RegradeEval(ctx context.Context, projectRoot, configPath, workflowName string, cfg *config.Config, caseName, runID string) (string, []CaseResult, error) {
+	if caseName == "" {
+		return "", nil, fmt.Errorf("eval: --regrade requires a case name")
+	}
+	cdir := caseDirFor(projectRoot, caseName)
+	fixture, err := LoadFixture(cdir)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: loading fixture for %q: %w", caseName, err)
+	}
+	rubric, err := LoadRubric(cdir, projectRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: loading rubric for %q: %w", caseName, err)
+	}
+
+	baseArtifacts := state.ArtifactsDirForWorkflow(projectRoot, workflowName, fixture.Ticket)
+	runDir, err := resolveRunArtifactsDir(baseArtifacts, runID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
+	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runDir, projectRoot, expandedVars)
+	if rubricErr != nil {
+		fmt.Fprintf(os.Stderr, "  warning: rubric evaluation error for %q: %v\n", caseName, rubricErr)
+	}
+	score := ComputeScore(criterionResults, rubric)
+
+	details := make(map[string]float64)
+	var failures []string
+	passCount := 0
+	for _, cr := range criterionResults {
+		details[cr.Name] = cr.Score
+		if cr.Pass {
+			passCount++
+		} else {
+			failures = append(failures, cr.Name+": "+cr.Detail)
+		}
+	}
+	rubricFP, _ := RubricFingerprint(rubric, cdir, projectRoot)
+
+	result := CaseResult{
+		Name:              caseName,
+		Score:             score,
+		PassCount:         passCount,
+		TotalCount:        len(criterionResults),
+		Failures:          failures,
+		Details:           details,
+		RubricFingerprint: rubricFP,
+		RegradedFrom:      filepath.Base(runDir),
+	}
+
+	fingerprint, err := ConfigFingerprint(configPath, cfg, projectRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: computing fingerprint: %w", err)
+	}
+	results := []CaseResult{result}
+
+	history, err := LoadHistory(projectRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: cannot load eval history, skipping save: %v\n", err)
+	} else {
+		history.AppendResult(fingerprint, results)
+		if err := SaveHistory(projectRoot, history); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: failed to save eval history: %v\n", err)
+		}
+	}
+	return fingerprint, results, nil
+}
+```
+
+- [ ] **Step 4: Wire the CLI flag**
+
+In `cmd/orc/eval.go`, add to `Flags`:
+
+```go
+			&cli.StringFlag{Name: "regrade", Usage: "Re-grade a saved run against the current rubric without re-running (optionally pass a run id)"},
+```
+
+After config load and `caseName` validation (after `eval.go` line ~86), branch before `RunEval`:
+
+```go
+			if cmd.IsSet("regrade") {
+				if caseName == "" {
+					return cfgErr(fmt.Errorf("--regrade requires a case name: orc eval <case> --regrade [run-id]"))
+				}
+				runID := cmd.String("regrade")
+				fingerprint, cases, err := eval.RegradeEval(ctx, projectRoot, configPath, workflowName, cfg, caseName, runID)
+				if err != nil {
+					return fmt.Errorf("re-grading eval: %w", err)
+				}
+				if cmd.Bool("json") {
+					return eval.RenderJSON(os.Stdout, fingerprint, cases)
+				}
+				eval.RenderScoreReport(os.Stdout, fingerprint, cases)
+				return nil
+			}
+```
+
+Note: `--regrade` takes an *optional* value. With urfave/cli a `StringFlag` whose value is empty when passed as a bare `--regrade` works via `cmd.IsSet("regrade")` true + `cmd.String("regrade")==""`. Document usage as `orc eval <case> --regrade` (latest) or `orc eval <case> --regrade <run-id>`.
+
+- [ ] **Step 5: Run tests + build to verify**
+
+Run: `go test ./internal/eval/ -count=1 && make build`
+Expected: PASS and a successful build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/eval.go cmd/orc/eval.go internal/eval/eval_test.go
+git commit -m "eval: add --regrade to re-score a saved run without re-running"
+```
+
+---
+
+## Task 7: Update documentation
+
+**Files:**
+- Modify: `internal/docs/content.go` (eval topic ~lines 1570–1693)
+
+**Interfaces:**
+- Consumes: nothing (doc strings only).
+- Produces: doc reflects `spec:` required field, `$ORC_EVAL`/`$ORC_SPEC_FILE` contract, the clean-stage/held-out-grader model, `--regrade`, two fingerprints, var-in-var alphabetical-order caveat, grader paths resolving from project root.
+
+- [ ] **Step 1: Update the eval doc string**
+
+In `internal/docs/content.go`, in the eval topic:
+
+1. Under "Eval Case Structure", add the spec file and note the holdout model:
+
+```
+  .orc/evals/
+  └── bug-fix/
+      ├── fixture.yaml     Git ref + ticket + spec to replay
+      ├── spec.md          Agent-visible input (the "ticket body")
+      └── rubric.yaml      Scoring criteria (HELD OUT from the agent)
+
+The whole .orc/evals/ directory is removed from the agent's worktree before the
+workflow runs, so the grader (rubric, judge prompts, held-out tests) is never
+visible to the workflow under test. orc reads the grader from your live project
+at grade time only.
+```
+
+2. In the `fixture.yaml` fields list, add:
+
+```
+  spec       Required. Filename (in the case dir) of the agent-visible spec —
+             the stand-in for a real ticket body. orc copies it into the stage
+             at .orc/eval-spec/spec.md and exposes its absolute path as
+             $ORC_SPEC_FILE (with $ORC_EVAL=1) so the workflow can read it
+             instead of fetching from an external store. This branch is an
+             optional convenience; a self-contained workflow needs no change.
+```
+
+3. Add a new section after `rubric.yaml`:
+
+```
+Eval Mode Contract
+------------------
+
+When a workflow runs under orc eval, orc sets two env vars:
+
+  ORC_EVAL=1                       Signals eval mode.
+  ORC_SPEC_FILE=<abs path>         Path to the case spec on the stage.
+
+A workflow whose ticket-fetch phase normally calls an external store (Jira,
+etc.) can branch on these:
+
+  if [ -n "$ORC_EVAL" ]; then
+    cat "$ORC_SPEC_FILE"
+  else
+    jira-cli get "$TICKET"
+  fi
+
+This is opt-in: orc neither enforces nor requires it. The agent's worktree is a
+clean git checkout of the fixture ref plus one curation commit (spec copied in,
+.orc/evals removed, live workflow written, .orc/artifacts and .orc/audit
+gitignored), so clean-tree guards in your workflow pass.
+
+Grader checks and judge prompts run from your live project root, receive the
+fixture vars (as KEY and ORC_KEY), and resolve relative paths from the project
+root. Fixture var-in-var references (e.g. SECOND: $FIRST/leaf) expand in
+alphabetical key order.
+```
+
+4. Update the command list (top) and "Typical Workflow" to mention `--regrade`:
+
+```
+  orc eval <case> --regrade            Re-grade the latest run of <case>
+  orc eval <case> --regrade <run-id>   Re-grade a specific saved run
+```
+
+Add to "Typical Workflow for Prompt Iteration" a second loop:
+
+```
+Iterating on the rubric (no workflow re-run):
+
+1. Run the case once:        orc eval bug-fix
+2. Edit rubric.yaml
+3. Re-grade the saved run:    orc eval bug-fix --regrade
+4. Repeat 2-3 — seconds each, no agent turns or build cost.
+```
+
+5. Update the "Config Fingerprint" section to mention the rubric fingerprint:
+
+```
+History rows also record a rubric fingerprint per case (rubric.yaml + judge
+prompt contents + check strings). The --report RUBRIC column lets you tell a
+score change caused by a workflow edit (FINGERPRINT changed) apart from one
+caused by a rubric edit (RUBRIC changed) — a re-grade shows the same
+FINGERPRINT with a new RUBRIC value.
+```
+
+- [ ] **Step 2: Build to verify the doc compiles**
+
+Run: `make build`
+Expected: successful build (doc strings are plain Go string literals).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/docs/content.go
+git commit -m "docs: document eval held-out grader, ORC_SPEC_FILE, --regrade, two fingerprints"
+```
+
+---
+
+## Task 8: Full suite + end-to-end smoke verification
+
+**Files:**
+- No new code; this is the integration gate.
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `make test`
+Expected: PASS across all packages. If `internal/eval` git-using tests fail in CI without git identity, confirm `initGitRepo` sets `user.email`/`user.name`/`commit.gpgsign=false` (it does) and that `gitCommitStage` passes `-c user.email=... -c user.name=...` (it does).
+
+- [ ] **Step 2: Build and check the binary**
+
+Run: `make build && ./orc eval --help`
+Expected: help text lists `--regrade`.
+
+- [ ] **Step 3: Manual smoke (optional, requires a project with an eval case)**
+
+In a scratch project that already uses orc with a `.orc/evals/<case>/` containing `fixture.yaml` (with `spec:`), `spec.md`, and `rubric.yaml`:
+
+```bash
+orc eval <case>                 # full run, then grade; note the run id in --report
+orc eval <case> --regrade       # re-grade latest, no workflow run
+orc eval --report               # see FINGERPRINT + RUBRIC columns and the regraded row
+```
+
+Expected: the second command completes in seconds (no agent turns); `--report` shows a new row with the same FINGERPRINT and a RUBRIC value, distinguishable as a re-grade.
+
+- [ ] **Step 4: Final commit (if any doc/test tweaks were needed)**
+
+```bash
+git add -A
+git commit -m "eval: integration verification for redesign"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Held-out grader (#9 P1) → Task 2 (`.orc/evals` removed in curation commit) + Task 3 (grader read from live project). ✓
+- Clean stage / dirty-tree (#9 P3) → Task 2 (curation commit + gitignore artifacts/audit; test asserts `git status` clean). ✓
+- Checks see vars (#9 P2) → Task 3 (`baseExtras` includes fixture vars as KEY/ORC_KEY; tests). ✓
+- Var-in-var (#9 P4) → Task 3 (`expandFixtureVars`; test). ✓
+- Spec injection seam / Jira-without-Jira (#9 Q1) → Task 4 (`ORC_EVAL`/`ORC_SPEC_FILE`) + Task 1 (`spec:` field). ✓
+- Re-grade without re-run (#8) → Task 6 (`RegradeEval`, `--regrade`). ✓
+- Two fingerprints → Task 5. ✓
+- Path-resolution base unified (spec Open Q3) → Task 3 (project root for both check + judge). ✓
+- Spec stage path (Open Q1) → Task 2 (`SpecStagePath` constant). ✓
+- Re-grade append + marker (Open Q5) → Task 5 (`RegradedFrom`) + Task 6 (sets it). ✓
+- Hard migration (Open Q4) → Task 1 (`spec` required). ✓
+- Adversarial reachability (Open Q6) → accepted out of scope; no task (intentional). ✓
+- Docs → Task 7. ✓
+
+**Placeholder scan:** No TBD/TODO; all code shown. The one design note — fixture var ordering is alphabetical because `Vars` is a `map` — is called out explicitly in Task 3 and documented in Task 7, not left vague. ✓
+
+**Type consistency:**
+- `EvaluateRubric(ctx, rubric, artifactsDir, projectRoot, vars)` — defined Task 3, called Task 3 (eval.go), Task 6 (RegradeEval). Consistent (5 params, no `worktreePath`). ✓
+- `RunWorkflow(ctx, worktreePath, ticket, workflowName, specFile, vars)` — defined Task 4, called Task 4. Consistent. ✓
+- `BuildStage(ctx, projectRoot, worktreePath, configPath, cfg, fixture, caseName)` — signature note in Task 2 reconciles the test (the test call must pass `caseName`); flagged inline. ✓
+- `RubricFingerprint(rubric, caseDir, projectRoot)` — defined Task 5, called Task 5 (runCase) + Task 6. Consistent. ✓
+- `CaseResult.RubricFingerprint` / `.RegradedFrom` — added Task 5, set Task 5/6, rendered Task 5. ✓
+- `caseDirFor(projectRoot, caseName)` helper — defined Task 2, used Task 2 (`BuildStage`) and Task 6 (`RegradeEval`). Named `caseDirFor` (not `caseDir`) so it does not collide with the existing local variable `caseDir` inside `runCase`. Applied consistently in all task bodies. ✓

--- a/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
@@ -100,8 +100,9 @@ orc's hands.
 ### Components
 
 - **Case dir `.orc/evals/<case>/`** — version-controlled, shared with the team:
-  - `fixture.yaml` — `ref`, `ticket`, `vars`, `description`, **new `spec:`**
-    field naming the agent-visible spec file (relative to the case dir).
+  - `fixture.yaml` — `ref`, `ticket`, `vars`, `description`, **new required
+    `spec:`** field naming the agent-visible spec file (relative to the case
+    dir). Required (hard migration — see Open Questions #4).
   - the **spec** file (e.g. `spec.md`) — the only thing extracted onto the stage.
   - `rubric.yaml` + any held-out test scripts / judge prompt files — held out by
     virtue of the whole `.orc/evals/` dir being removed from the stage. **There
@@ -138,9 +139,12 @@ orc's hands.
     `if [ -n "$ORC_EVAL" ]; then cat "$ORC_SPEC_FILE"; else <fetch from Jira>; fi`.
   - orc owns the two primitives; the workflow owns ticketing. This leak of "this
     is an eval" into the workflow is intentional and minimal (one conditional in
-    one phase) and is unavoidable because ticket-fetching is the workflow's job.
-    A workflow that omits the branch will attempt to resolve a non-existent
-    ticket and fail; orc does not (and cannot) force the opt-in.
+    one phase). **It is opt-in, not required.** The branch is a QOL convenience
+    only for workflows that resolve tickets via an *external* store (Jira, etc.)
+    and thus need a local stand-in under eval. A workflow whose ticket is already
+    self-contained needs no branch at all. orc neither enforces nor needs the
+    opt-in; a workflow that hits an external store with a fake eval ticket id and
+    omits the branch will simply fail — that is the author's choice to make.
 
 - **Grade step** (extracted from the run path; this is what makes #8 possible):
   - A pure function of `(run artifacts, grader)`.
@@ -185,10 +189,12 @@ orc's hands.
 
 - Stage build failures (worktree add, curation commit) abort the case with a
   wrapped error; the worktree is pruned/removed (existing teardown logic).
-- A missing `spec:` file in the fixture is a config error at load time.
+- A missing or absent `spec:` field/file in the fixture is a config error at
+  load time (hard migration — `spec:` is required).
 - A workflow that does not honor the eval-mode contract (never reads
-  `$ORC_SPEC_FILE`) is not orc's failure to detect; document the contract
-  clearly. (Optional future: a doctor check.)
+  `$ORC_SPEC_FILE`) is not orc's failure to detect — the contract is opt-in QOL,
+  not required. Document it clearly. (Optional future: a doctor check that warns
+  when a workflow fetches tickets externally but has no eval branch.)
 - Grade-step failures (bad check, judge error) are recorded per-criterion as
   today (fail with detail), never crashing the whole eval.
 - `--regrade` with no saved run for the case is a clear error listing available
@@ -226,9 +232,11 @@ orc's hands.
    writing artifacts outside the worktree.
 3. **Path-resolution base for grader `check:`/`prompt:`.** Pick one consistent
    base now that the grader is read from the live project; document it.
-4. **Backward compatibility.** Existing eval cases have no `spec:` field and rely
-   on `ref` containing the spec. Decide: hard migration (require `spec:`),
-   or `spec:`-optional (no spec injected; old behavior) with a deprecation note.
+4. ~~**Backward compatibility.**~~ **Resolved: hard migration.** `spec:` is
+   required; there is no fallback to "spec lives in the ref." The feature has no
+   real-world users yet, so carrying optionality isn't worth it. Existing cases
+   (if any) must add a `spec:` field. A clear config-load error names the missing
+   field.
 5. **Re-grade history semantics.** Does a re-grade row replace or append? (Design
    leans append, so deltas are visible.) How is a re-grade row marked in
    `--report`?

--- a/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
@@ -126,13 +126,21 @@ orc's hands.
     the tree mid-run. (See Open Questions.)
 
 - **Eval-mode contract** (the spec-injection seam — **#9 P1 / Q1**):
-  - orc sets `ORC_EVAL=1` and `ORC_SPEC_FILE=<abs path in stage>` in the
-    workflow's environment.
+  - orc sets **two primitives** in the workflow's environment:
+    - `ORC_EVAL=1` — the eval-mode flag the workflow branches on.
+    - `ORC_SPEC_FILE=<abs path in stage>` — absolute path to a file on the stage
+      containing this case's spec (the "ticket body"). Its contents are the
+      case's authored `spec.md`, copied onto the stage during stage build (the
+      one file extracted from the case dir before `.orc/evals/` is removed). It
+      is a *plain file path*, not a ticket abstraction — orc deliberately does
+      not model ticketing.
   - The workflow's ticket-fetch phase is expected to branch:
     `if [ -n "$ORC_EVAL" ]; then cat "$ORC_SPEC_FILE"; else <fetch from Jira>; fi`.
   - orc owns the two primitives; the workflow owns ticketing. This leak of "this
     is an eval" into the workflow is intentional and minimal (one conditional in
     one phase) and is unavoidable because ticket-fetching is the workflow's job.
+    A workflow that omits the branch will attempt to resolve a non-existent
+    ticket and fail; orc does not (and cannot) force the opt-in.
 
 - **Grade step** (extracted from the run path; this is what makes #8 possible):
   - A pure function of `(run artifacts, grader)`.
@@ -209,11 +217,10 @@ orc's hands.
 
 ## Open questions (to resolve in the implementation plan)
 
-1. **Exact `$ORC_SPEC_FILE` path on the stage.** Options: under
-   `.orc/artifacts/` (already orc-owned, but artifacts dir is per-run), a
-   dedicated `.orc/eval-spec/…`, or a fixture-declarable path. Must not collide
-   with real workflow files and must be stable for the ticket-fetch phase to
-   find.
+1. **Exact `$ORC_SPEC_FILE` path on the stage.** Leaning to a dedicated,
+   stable, orc-owned path: `.orc/eval-spec/spec.md`. Rejected `.orc/artifacts/`
+   (per-run, orc-churned — a poor home for a stable input). Confirm the exact
+   path and whether it should be fixture-overridable.
 2. **Excluding `artifacts/`/`audit/` from dirtying the stage mid-run.** Append to
    `.gitignore` in the curation commit, vs. a documented expectation, vs.
    writing artifacts outside the worktree.

--- a/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-23-eval-redesign-design.md
@@ -1,0 +1,231 @@
+# orc eval redesign — held-out grader, clean stage, separable grading
+
+**Date:** 2026-06-23
+**Status:** Design — pending implementation plan
+**Related issues:** #8 (re-grade without re-run), #9 (no agent-input/grader separation; check var access; injected-prompt dirty tree; var-in-var expansion)
+**Supersedes the mechanism of:** R-034 (`orc-9zj.4`), `internal/eval/`
+
+## Problem
+
+`orc eval` was built (R-034) as a workflow quality-regression tracker: change a
+prompt, re-run, see whether the score moved and at what cost. The measurement is
+only trustworthy if the grader (tests, rubric) is **held out** from the workflow
+under test — otherwise the score measures "can the agent see and satisfy the
+test," not "did the workflow produce good work." Running held-out tests (plus a
+soft agent-as-judge fallback) is the only real way to measure quality. So
+held-out separation is not a new use case bolted onto eval; it is the missing
+piece that makes the *original* regression-tracking goal honest.
+
+The current implementation collapses four distinct concerns into a single
+`git checkout <ref>`:
+
+1. the **workflow under test** (should be live),
+2. the **target codebase** (should be pinned to `ref`),
+3. **agent input** — the ticket/spec the agent must read,
+4. the **held-out grader** — rubric + tests the agent must NOT see.
+
+Because `.orc/evals/<case>/` lives in the repo, it is part of the `ref`
+checkout, so no choice of `ref` can both expose the spec and hide the grader.
+The current code also *injects live prompt files over the ref checkout*
+(`copyOrcDir` in `internal/eval/eval.go`), which dirties the worktree and trips
+the very common "abort if the tree is dirty" workflow guard.
+
+### Concrete gaps this design closes
+
+- **#9 P1** — no separation of agent-visible input vs held-out grader.
+- **#9 P2** — rubric `check:` scripts can't read fixture `vars`
+  (`internal/eval/rubric.go` builds the check env without them).
+- **#9 P3** — injected live prompts (and untracked `artifacts/`/`audit/` dirs)
+  make `git status` dirty inside the worktree; clean-tree guards trip on orc's
+  own scaffolding.
+- **#9 P4** — fixture `vars` injected into child env are passed literally, so
+  `TICKET_FILE: $LIVE_ROOT/x` arrives unexpanded.
+- **#8** — no way to re-grade a finished run against an edited rubric without
+  paying a full workflow execution.
+
+## Key insight / design philosophy
+
+Two failed directions were considered and rejected during design, and the
+rejections define the principle:
+
+- **"Subtract the grader from the checkout at runtime"** dirties the tree (the
+  reintroduction of #9 P3). Dead.
+- **"Build a smart commit that reconstructs a realistic repo state / synthetic
+  repo"** is undesignable: it makes orc compete with every project's git
+  conventions and lose on the long tail. Dead.
+
+The principle that survives: **orc should do *less* and never try to be smart
+about the repo.** orc applies only edits it *already knows exactly* — its own
+live config, its own removal of its own `.orc/evals/` dir, and the case's own
+spec file. It never infers repo conventions.
+
+The resolution of the central contention (the grader must be both
+version-controlled in the repo *and* invisible to the agent) is **temporal, not
+spatial**: the grader lives in `.orc/evals/` in real git history (shared with
+the team), but is *physically absent from the agent's stage* and read by orc
+directly from the live project only at grade time.
+
+Likewise, ticket-fetching is the **workflow's** job, not orc's. orc must not
+invent a "ticket source" abstraction. It provides two dumb primitives — a spec
+file at a known path, and an eval-mode flag — and the workflow opts in with one
+conditional in its ticket-fetch phase. This is the only generalizable contract;
+how each project resolves a real ticket (Jira, etc.) is deliberately out of
+orc's hands.
+
+## Architecture
+
+`orc eval` becomes a **stage builder + separable grader**:
+
+```
+                  ┌─────────────────────── live project ───────────────────────┐
+                  │  .orc/<workflow files>   .orc/evals/<case>/{fixture,spec,    │
+                  │  (live, under test)        rubric, held-out tests}           │
+                  └───────────────┬───────────────────────────┬─────────────────┘
+                                  │ (1) build stage            │ (3) grade reads
+                                  ▼                            │     grader from
+   git worktree add <ref>  ──►  curate + commit               │     LIVE project
+   (pinned target)              · copy spec → $ORC_SPEC_FILE   │     (never the
+                                · rm -rf .orc/evals/           │      worktree)
+                                · write live workflow files    │
+                                · git add -A && git commit     │
+                                  ▼                            │
+                        CLEAN, GRADER-FREE STAGE               │
+                                  │ (2) run workflow           │
+                                  ▼                            │
+                              artifacts ─────────────────────► grade step
+                                  │                            (artifacts + grader)
+                              saved for re-grade ◄─────────────────────┘ (#8)
+```
+
+### Components
+
+- **Case dir `.orc/evals/<case>/`** — version-controlled, shared with the team:
+  - `fixture.yaml` — `ref`, `ticket`, `vars`, `description`, **new `spec:`**
+    field naming the agent-visible spec file (relative to the case dir).
+  - the **spec** file (e.g. `spec.md`) — the only thing extracted onto the stage.
+  - `rubric.yaml` + any held-out test scripts / judge prompt files — held out by
+    virtue of the whole `.orc/evals/` dir being removed from the stage. **There
+    is no per-file holdout rule; the rule is simply ".orc/evals/ is not on the
+    stage."**
+
+- **Stage builder** (replaces `CreateWorktree` + `copyOrcDir`):
+  1. `git worktree add <tmp> <ref>` — vanilla checkout of the pinned target.
+  2. Copy the case spec from the live project to `$ORC_SPEC_FILE` inside the
+     stage (a known path; see Open Questions for exact path).
+  3. `rm -rf <stage>/.orc/evals/` — `.orc` is always at repo root, so this is
+     unambiguous and requires no repo intelligence.
+  4. Write the **live** workflow/phase/prompt files into the stage (the thing
+     under test), overwriting the ref's committed copies.
+  5. `git add -A && git commit -m "orc eval stage: <case>"` on the worktree's
+     branch.
+  - Result: `git status` is empty (clean-tree guards pass — **#9 P3**), the
+    grader/evals dir is absent (**#9 P1**), the live workflow runs against the
+    pinned target.
+  - `.orc/artifacts/` and `.orc/audit/` are produced *during* the run; they must
+    be `.gitignore`d on the stage (or otherwise excluded) so they don't re-dirty
+    the tree mid-run. (See Open Questions.)
+
+- **Eval-mode contract** (the spec-injection seam — **#9 P1 / Q1**):
+  - orc sets `ORC_EVAL=1` and `ORC_SPEC_FILE=<abs path in stage>` in the
+    workflow's environment.
+  - The workflow's ticket-fetch phase is expected to branch:
+    `if [ -n "$ORC_EVAL" ]; then cat "$ORC_SPEC_FILE"; else <fetch from Jira>; fi`.
+  - orc owns the two primitives; the workflow owns ticketing. This leak of "this
+    is an eval" into the workflow is intentional and minimal (one conditional in
+    one phase) and is unavoidable because ticket-fetching is the workflow's job.
+
+- **Grade step** (extracted from the run path; this is what makes #8 possible):
+  - A pure function of `(run artifacts, grader)`.
+  - The grader (rubric + checks + judge prompts) is read from the **live
+    project**, never from the worktree.
+  - `check:` scripts and judge invocations receive the fixture `vars` (**#9
+    P2**), expanded so var-in-var references resolve (**#9 P4**).
+  - Path-resolution base is documented and consistent (the prior surprise of
+    judge `prompt:` resolving from project root while `check:` relative paths
+    resolved from the worktree is removed / documented — see Open Questions).
+
+- **Re-grade** (**#8**):
+  - `orc eval <case> --regrade [<run-id>]` runs only the grade step against a
+    saved run's artifacts; default targets the most recent run for the case.
+  - Writes a new history row so `--report` shows the score delta.
+  - Requires run artifacts to be retained/locatable after a run (the existing
+    history-archive logic in `RunWorkflow` already moves artifacts to
+    `history/<run-id>/`; re-grade reads from there).
+
+- **History & fingerprints** (**two fingerprints**):
+  - Each history row records a **workflow fingerprint** (config + prompt/run
+    files, as today) AND a separate **rubric fingerprint** (rubric.yaml + held-out
+    test files + judge prompts).
+  - This lets `--report` distinguish "score moved because the workflow changed"
+    (workflow-fp changed) from "score moved because the ruler changed"
+    (rubric-fp changed) — and makes a re-grade legible as same workflow-fp / new
+    rubric-fp.
+
+### Data flow
+
+1. `orc eval <case>` → load fixture + rubric from live project.
+2. Build stage (worktree at `ref` + curation commit).
+3. Run workflow on stage with `ORC_EVAL` / `ORC_SPEC_FILE` set; collect artifacts,
+   cost, duration; save artifacts under a run id.
+4. Grade: evaluate rubric (read from live project) against artifacts; checks/judge
+   get fixture `vars`.
+5. Compute score; append history row (workflow-fp + rubric-fp); render report.
+6. `orc eval <case> --regrade [run-id]` repeats only steps 4–5 against saved
+   artifacts.
+
+### Error handling
+
+- Stage build failures (worktree add, curation commit) abort the case with a
+  wrapped error; the worktree is pruned/removed (existing teardown logic).
+- A missing `spec:` file in the fixture is a config error at load time.
+- A workflow that does not honor the eval-mode contract (never reads
+  `$ORC_SPEC_FILE`) is not orc's failure to detect; document the contract
+  clearly. (Optional future: a doctor check.)
+- Grade-step failures (bad check, judge error) are recorded per-criterion as
+  today (fail with detail), never crashing the whole eval.
+- `--regrade` with no saved run for the case is a clear error listing available
+  run ids.
+
+### Testing
+
+- Stage builder: assert the stage is git-clean after build, `.orc/evals/` is
+  absent, live workflow files are present, spec is at `$ORC_SPEC_FILE`.
+- Eval-mode contract: a fixture workflow whose ticket-fetch phase reads
+  `$ORC_SPEC_FILE` produces artifacts derived from the spec.
+- Grade step purity: same artifacts + same rubric → same score; editing the
+  rubric and re-grading changes the score without re-running.
+- `vars` reach checks (**#9 P2**) and expand (**#9 P4**) — unit + integration.
+- Two-fingerprint history: editing only the rubric changes rubric-fp not
+  workflow-fp; `--report` renders both.
+- `--regrade` targets latest run by default and a named run by id.
+
+## What stays the same
+
+- Case discovery (`.orc/evals/<case>/`), `--list`, `--report`, `--json`.
+- Judge mechanism (`claude -p`, `SCORE: N` extraction, normalization, `expect`
+  operators), script `check`/`expect` semantics, weighted composite scoring.
+- Cost/duration as first-class outputs.
+- Worktree isolation and process-group teardown.
+
+## Open questions (to resolve in the implementation plan)
+
+1. **Exact `$ORC_SPEC_FILE` path on the stage.** Options: under
+   `.orc/artifacts/` (already orc-owned, but artifacts dir is per-run), a
+   dedicated `.orc/eval-spec/…`, or a fixture-declarable path. Must not collide
+   with real workflow files and must be stable for the ticket-fetch phase to
+   find.
+2. **Excluding `artifacts/`/`audit/` from dirtying the stage mid-run.** Append to
+   `.gitignore` in the curation commit, vs. a documented expectation, vs.
+   writing artifacts outside the worktree.
+3. **Path-resolution base for grader `check:`/`prompt:`.** Pick one consistent
+   base now that the grader is read from the live project; document it.
+4. **Backward compatibility.** Existing eval cases have no `spec:` field and rely
+   on `ref` containing the spec. Decide: hard migration (require `spec:`),
+   or `spec:`-optional (no spec injected; old behavior) with a deprecation note.
+5. **Re-grade history semantics.** Does a re-grade row replace or append? (Design
+   leans append, so deltas are visible.) How is a re-grade row marked in
+   `--report`?
+6. **Adversarial reachability (accepted as out of scope for now).** The grader
+   remains reachable via `git show <ref>:.orc/evals/...` because `ref` is an
+   ancestor of the curation commit. Accepted: the threat model is accidental
+   context-pollution, not a cheating agent. Revisit only if that changes.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -148,6 +148,15 @@ func BuildEnv(env *Environment) []string {
 		"WORK_DIR="+env.WorkDir,
 		"PROJECT_ROOT="+env.ProjectRoot,
 	)
+	// Passthrough allowlist: re-emit the eval-mode contract vars stripped by the
+	// ORC_* filter above so they reach workflow phases (the ticket-fetch seam
+	// reads ORC_EVAL/ORC_SPEC_FILE). Only when actually set, so non-eval runs
+	// and existing callers are unaffected. Placed last so nothing shadows them.
+	for _, k := range []string{"ORC_EVAL", "ORC_SPEC_FILE"} {
+		if v, ok := os.LookupEnv(k); ok {
+			result = append(result, k+"="+v)
+		}
+	}
 	return result
 }
 

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,6 +1,9 @@
 package dispatch
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -178,6 +181,100 @@ func TestBuildEnv_StripsCLAUDECODE(t *testing.T) {
 	for _, e := range result {
 		if strings.HasPrefix(e, "CLAUDECODE") {
 			t.Fatalf("CLAUDECODE var not stripped: %s", e)
+		}
+	}
+}
+
+// BLOCKING 1: ORC_EVAL/ORC_SPEC_FILE must pass through BuildEnv to phases.
+
+func TestBuildEnv_PassesThroughEvalVars(t *testing.T) {
+	t.Setenv("ORC_EVAL", "1")
+	t.Setenv("ORC_SPEC_FILE", "/stage/.orc/eval-spec/spec.md")
+	// A non-allowlisted ORC_ var must still be stripped.
+	t.Setenv("ORC_LEAKED", "should-be-stripped")
+
+	env := &Environment{
+		ProjectRoot:  "/proj",
+		WorkDir:      "/work",
+		ArtifactsDir: "/art",
+		Ticket:       "T-1",
+	}
+	result := BuildEnv(env)
+
+	find := func(key string) (string, bool) {
+		for _, e := range result {
+			if strings.HasPrefix(e, key+"=") {
+				return strings.TrimPrefix(e, key+"="), true
+			}
+		}
+		return "", false
+	}
+
+	if v, ok := find("ORC_EVAL"); !ok || v != "1" {
+		t.Fatalf("ORC_EVAL not passed through: %q (found=%v)", v, ok)
+	}
+	if v, ok := find("ORC_SPEC_FILE"); !ok || v != "/stage/.orc/eval-spec/spec.md" {
+		t.Fatalf("ORC_SPEC_FILE not passed through: %q (found=%v)", v, ok)
+	}
+	if _, ok := find("ORC_LEAKED"); ok {
+		t.Fatal("non-allowlisted ORC_ var leaked through BuildEnv")
+	}
+}
+
+// TestRunScript_PropagatesEvalVars proves end-to-end that a real script phase
+// dispatched through RunScript -> BuildEnv -> bash sees ORC_EVAL/ORC_SPEC_FILE.
+func TestRunScript_PropagatesEvalVars(t *testing.T) {
+	t.Setenv("ORC_EVAL", "1")
+	t.Setenv("ORC_SPEC_FILE", "/stage/.orc/eval-spec/spec.md")
+
+	artifactsDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(artifactsDir, "logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outFile := filepath.Join(artifactsDir, "captured.txt")
+	env := &Environment{
+		ProjectRoot:  artifactsDir,
+		WorkDir:      artifactsDir,
+		ArtifactsDir: artifactsDir,
+		Ticket:       "T-1",
+		AutoMode:     true,
+	}
+	phase := config.Phase{
+		Name: "echo-eval",
+		Type: "script",
+		Run:  `printf '%s\n%s\n' "$ORC_EVAL" "$ORC_SPEC_FILE" > "` + outFile + `"`,
+	}
+	res, err := RunScript(context.Background(), phase, env)
+	if err != nil {
+		t.Fatalf("RunScript error: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("script exit code = %d, want 0", res.ExitCode)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading captured output: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "1") || !strings.Contains(got, "/stage/.orc/eval-spec/spec.md") {
+		t.Fatalf("script did not see eval vars; captured:\n%s", got)
+	}
+}
+
+func TestBuildEnv_NoEvalVarsWhenUnset(t *testing.T) {
+	// When the eval contract vars are absent, BuildEnv must not invent them.
+	os.Unsetenv("ORC_EVAL")
+	os.Unsetenv("ORC_SPEC_FILE")
+	env := &Environment{
+		ProjectRoot:  "/proj",
+		WorkDir:      "/work",
+		ArtifactsDir: "/art",
+		Ticket:       "T-1",
+	}
+	result := BuildEnv(env)
+	for _, e := range result {
+		if strings.HasPrefix(e, "ORC_EVAL=") || strings.HasPrefix(e, "ORC_SPEC_FILE=") {
+			t.Fatalf("unexpected eval var emitted when unset: %s", e)
 		}
 	}
 }

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -1578,11 +1578,17 @@ Why it matters: it's easy to accidentally regress quality when tweaking
 prompts. orc eval gives you a before/after score so you can iterate with
 confidence.
 
-  orc eval                     Run all eval cases
-  orc eval bug-fix             Run a specific case
-  orc eval --report            Show score history across config versions
-  orc eval --list              List available eval cases
-  orc eval --json              Structured JSON output
+  orc eval                            Run all eval cases
+  orc eval bug-fix                    Run a specific case
+  orc eval bug-fix --regrade          Re-grade the latest run of a case
+  orc eval bug-fix --regrade <run-id> Re-grade a specific saved run
+  orc eval --report                   Show score history across config versions
+  orc eval --list                     List available eval cases
+  orc eval --json                     Structured JSON output
+
+The --regrade flag is a boolean: it re-scores a saved run instead of running
+the workflow again. With no run-id it re-grades the latest run of the case; you
+can name a specific run-id as a trailing argument to re-grade an older run.
 
 Eval Case Structure
 -------------------
@@ -1591,14 +1597,21 @@ Each case lives in .orc/evals/<case-name>/:
 
   .orc/evals/
   └── bug-fix/
-      ├── fixture.yaml     Git ref + ticket to replay
-      └── rubric.yaml      Scoring criteria
+      ├── fixture.yaml     Git ref + ticket + spec to replay
+      ├── spec.md          Agent-visible input (the "ticket body")
+      └── rubric.yaml      Scoring criteria (HELD OUT from the agent)
+
+The whole .orc/evals/ directory is removed from the agent's worktree before the
+workflow runs, so the grader (rubric, judge prompts, held-out tests) is never
+visible to the workflow under test. orc reads the grader from your live project
+at grade time only.
 
 fixture.yaml
 ------------
 
   ref: abc123f              Git ref to check out (branch, tag, commit SHA)
   ticket: BUG-42            Ticket identifier passed to orc run
+  spec: spec.md             Filename (in the case dir) of the agent-visible spec
   description: "Fix the parser bug"   Optional human-readable description
   vars:                     Optional extra variables passed to the workflow
     EXTRA: value
@@ -1607,6 +1620,12 @@ Fields:
   ref        Required. Any valid git ref — branch, tag, or commit SHA.
              Must match ^[A-Za-z0-9._/~^{}-]+$ (no shell metacharacters).
   ticket     Required. Must be a simple name (no path separators).
+  spec       Required. Filename (in the case dir) of the agent-visible spec —
+             the stand-in for a real ticket body. orc copies it into the stage
+             at .orc/eval-spec/spec.md and exposes its absolute path as
+             $ORC_SPEC_FILE (with $ORC_EVAL=1) so the workflow can read it
+             instead of fetching from an external store. This branch is an
+             optional convenience; a self-contained workflow needs no change.
   description Optional. Shown by orc eval --list.
   vars       Optional. Key-value pairs injected as env vars into the workflow
              (available as both KEY and ORC_KEY).
@@ -1640,6 +1659,33 @@ Criterion types:
     expect    Comparison against the raw score: ">= 7", "> 5", "<= 3", "< 5", "== 10".
     weight    Relative weight for composite score.
 
+Eval Mode Contract
+------------------
+
+When a workflow runs under orc eval, orc sets two env vars:
+
+  ORC_EVAL=1                       Signals eval mode.
+  ORC_SPEC_FILE=<abs path>         Path to the case spec on the stage.
+
+A workflow whose ticket-fetch phase normally calls an external store (Jira,
+etc.) can branch on these:
+
+  if [ -n "$ORC_EVAL" ]; then
+    cat "$ORC_SPEC_FILE"
+  else
+    jira-cli get "$TICKET"
+  fi
+
+This is opt-in: orc neither enforces nor requires it. The agent's worktree is a
+clean git checkout of the fixture ref plus one curation commit (spec copied in,
+.orc/evals removed, live workflow written, .orc/artifacts and .orc/audit
+gitignored), so clean-tree guards in your workflow pass.
+
+Grader checks and judge prompts run from your live project root, receive the
+fixture vars (as KEY and ORC_KEY), and resolve relative paths from the project
+root. Fixture var-in-var references (e.g. SECOND: $FIRST/leaf) expand in
+alphabetical key order.
+
 Score Report
 ------------
 
@@ -1665,6 +1711,12 @@ and all referenced prompt files. It changes whenever you edit config.yaml or
 any prompt — making it easy to correlate score changes to config changes in
 the history report.
 
+History rows also record a rubric fingerprint per case (rubric.yaml + judge
+prompt contents + check strings). The --report RUBRIC column lets you tell a
+score change caused by a workflow edit (FINGERPRINT changed) apart from one
+caused by a rubric edit (RUBRIC changed) — a re-grade shows the same
+FINGERPRINT with a new RUBRIC value.
+
 History Tracking
 ----------------
 
@@ -1675,12 +1727,14 @@ config fingerprint. Use --report to view score trends:
 
   orc eval --report — score history
 
-  FINGERPRINT  DATE          AVG SCORE  TOTAL COST  TOTAL TIME
-  a1b2c3       Mar 01 15:30  75/100     $8.10       44m 45s
-  d4e5f6       Feb 28 10:15  68/100     $12.30      52m 18s
+  FINGERPRINT  RUBRIC   DATE          AVG SCORE  TOTAL COST  TOTAL TIME
+  a1b2c3       9f8e7d   Mar 01 15:30  75/100     $8.10       44m 45s
+  a1b2c3       7c6b5a   Mar 01 16:05  71/100     $0.04       0m 03s
+  d4e5f6       9f8e7d   Feb 28 10:15  68/100     $12.30      52m 18s
 
 This lets you see at a glance whether a config change improved or regressed
-quality, and at what cost.
+quality, and at what cost. The second row above is a re-grade: same
+FINGERPRINT, new RUBRIC, near-zero cost and time (no agent turns).
 
 Typical Workflow for Prompt Iteration
 --------------------------------------
@@ -1690,6 +1744,13 @@ Typical Workflow for Prompt Iteration
 3. Edit a prompt or config
 4. Run again:       orc eval
 5. Compare:         orc eval --report
+
+Iterating on the rubric (no workflow re-run):
+
+1. Run the case once:        orc eval bug-fix
+2. Edit rubric.yaml
+3. Re-grade the saved run:    orc eval bug-fix --regrade
+4. Repeat 2-3 — seconds each, no agent turns or build cost.
 `
 
 // SchemaReference returns the combined config schema, phase types, and

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -107,9 +107,18 @@ func LoadFixture(caseDir string) (*Fixture, error) {
 		"PHASE_INDEX": true, "PHASE_COUNT": true,
 		"WORKFLOW": true,
 	}
+	// Fixture vars are injected BARE (unprefixed) into the run env AND the
+	// grader env, last-wins, so a var named PATH/HOME/etc. would shadow the
+	// real one and corrupt bash/claude. Reject the dangerous names.
+	dangerous := map[string]bool{
+		"PATH": true, "HOME": true, "IFS": true, "SHELL": true,
+	}
 	for k := range f.Vars {
 		if builtins[k] {
 			return nil, fmt.Errorf("eval: fixture.yaml: var %q overrides a built-in variable", k)
+		}
+		if dangerous[k] || strings.HasPrefix(k, "LD_") || strings.HasPrefix(k, "DYLD_") {
+			return nil, fmt.Errorf("eval: fixture.yaml: var %q shadows a critical environment variable", k)
 		}
 	}
 	return &f, nil
@@ -343,6 +352,7 @@ func copyFile(src, dst string) error {
 // RunResult holds the outcome of running orc in a worktree.
 type RunResult struct {
 	ArtifactsDir    string
+	RunID           string // archived run id (history dir name), empty if not archived
 	CostUSD         float64
 	DurationSeconds float64
 	Status          string
@@ -423,9 +433,11 @@ func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName, specFi
 	// After a successful run, the runner archives artifacts to history/<run-id>/
 	// and removes the originals. Detect this and load from the archive instead.
 	loadDir := artifactsDir
+	runID := ""
 	if runErr == nil && !state.HasState(artifactsDir) {
 		if histDir, err := state.LatestHistoryDir(artifactsDir); err == nil && histDir != "" {
 			loadDir = histDir
+			runID = filepath.Base(histDir)
 		}
 	}
 
@@ -443,6 +455,7 @@ func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName, specFi
 
 	result := &RunResult{
 		ArtifactsDir: loadDir,
+		RunID:        runID,
 		Status:       status,
 		Err:          runErr,
 	}
@@ -540,8 +553,20 @@ func (e *evalRunner) runCase(ctx context.Context, caseName string) (CaseResult, 
 		return CaseResult{Name: caseName}, fmt.Errorf("eval: building stage for %q: %w", caseName, err)
 	}
 
-	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, specFile, fixture.Vars)
+	// Expand var-in-var references ONCE and use the SAME map for the workflow
+	// run env and the grader env, so e.g. "$LIVE_ROOT/t" resolves identically
+	// for both sides.
 	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
+
+	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, specFile, expandedVars)
+
+	// Persist the archived run out of the throwaway worktree into the live
+	// project (before the deferred RemoveWorktree deletes it), so `--regrade`
+	// can find it later.
+	if err := persistRunArtifacts(e.projectRoot, e.workflowName, fixture.Ticket, worktreePath, runResult.RunID); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: failed to persist run artifacts for %q: %v\n", caseName, err)
+	}
+
 	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, e.projectRoot, expandedVars)
 	if rubricErr != nil {
 		fmt.Fprintf(os.Stderr, "  warning: rubric evaluation error for %q: %v\n", caseName, rubricErr)
@@ -573,7 +598,10 @@ func (e *evalRunner) runCase(ctx context.Context, caseName string) (CaseResult, 
 	if runResult.Err != nil {
 		result.WorkflowErr = runResult.Err.Error()
 	}
-	rubricFP, _ := RubricFingerprint(rubric, caseDir, e.projectRoot)
+	rubricFP, fpErr := RubricFingerprint(rubric, caseDir, e.projectRoot)
+	if fpErr != nil {
+		fmt.Fprintf(os.Stderr, "  warning: computing rubric fingerprint for %q: %v\n", caseName, fpErr)
+	}
 	result.RubricFingerprint = rubricFP
 	return result, nil
 }
@@ -639,6 +667,36 @@ func RunEval(ctx context.Context, projectRoot, configPath, workflowName string, 
 	return fingerprint, results, nil
 }
 
+// persistRunArtifacts copies an eval run's archived artifacts out of the
+// throwaway worktree (where the workflow ran with cwd=worktree, so artifacts
+// archived to <worktree>/.orc/artifacts/.../history/<run-id>/) into a stable
+// location under the LIVE project root — the same path RegradeEval reads from.
+// This must run BEFORE the worktree is removed.
+//
+// NOTE: the live location is keyed by workflow + ticket + run-id. If a real
+// (non-eval) run of the same workflow/ticket exists, the eval run is stored
+// alongside it under its own timestamped run-id (no collision in practice; a
+// real and eval ticket sharing a name is the user's choice).
+func persistRunArtifacts(projectRoot, workflowName, ticket, worktreePath, runID string) error {
+	if runID == "" {
+		return nil // run wasn't archived (e.g. failed run) — nothing to persist
+	}
+	srcArtifacts := state.ArtifactsDirForWorkflow(worktreePath, workflowName, ticket)
+	src := filepath.Join(state.HistoryDir(srcArtifacts), runID)
+	if !state.HasState(src) {
+		return fmt.Errorf("eval: persistRunArtifacts: archived run %q not found in worktree at %s", runID, src)
+	}
+	dstArtifacts := state.ArtifactsDirForWorkflow(projectRoot, workflowName, ticket)
+	dst := filepath.Join(state.HistoryDir(dstArtifacts), runID)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("eval: persistRunArtifacts: creating history dir: %w", err)
+	}
+	if err := state.CopyTree(src, dst); err != nil {
+		return fmt.Errorf("eval: persistRunArtifacts: copying run %q: %w", runID, err)
+	}
+	return nil
+}
+
 // resolveRunArtifactsDir returns the artifacts dir for a saved run. If runID is
 // empty, returns the most recent history entry. Errors if the named run or any
 // history is absent.
@@ -652,6 +710,11 @@ func resolveRunArtifactsDir(artifactsDir, runID string) (string, error) {
 			return "", fmt.Errorf("eval: no saved runs found under %s", state.HistoryDir(artifactsDir))
 		}
 		return latest, nil
+	}
+	// Defensive path-traversal guard: a run id must be a single path element.
+	// The cmd layer validates too, but RegradeEval is a library entry point.
+	if runID == "." || runID == ".." || runID != filepath.Base(runID) {
+		return "", fmt.Errorf("eval: invalid run id %q: must not contain path separators", runID)
 	}
 	dir := filepath.Join(state.HistoryDir(artifactsDir), runID)
 	if !state.HasState(dir) {
@@ -700,7 +763,10 @@ func RegradeEval(ctx context.Context, projectRoot, configPath, workflowName stri
 			failures = append(failures, cr.Name+": "+cr.Detail)
 		}
 	}
-	rubricFP, _ := RubricFingerprint(rubric, cdir, projectRoot)
+	rubricFP, fpErr := RubricFingerprint(rubric, cdir, projectRoot)
+	if fpErr != nil {
+		fmt.Fprintf(os.Stderr, "  warning: computing rubric fingerprint for %q: %v\n", caseName, fpErr)
+	}
 
 	result := CaseResult{
 		Name:              caseName,

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -213,6 +213,36 @@ func ConfigFingerprint(configPath string, cfg *config.Config, projectRoot string
 	return hex.EncodeToString(h.Sum(nil))[:8], nil
 }
 
+// RubricFingerprint hashes the rubric's grading inputs: each criterion's
+// name/weight/expect/check/judge plus the contents of each judge prompt file
+// (resolved from projectRoot). Returns 8 hex chars, stable and
+// order-independent across criteria.
+func RubricFingerprint(rubric *Rubric, caseDir, projectRoot string) (string, error) {
+	h := sha256.New()
+	// Sort criteria by name for determinism.
+	names := make([]string, len(rubric.Criteria))
+	byName := make(map[string]Criterion, len(rubric.Criteria))
+	for i, c := range rubric.Criteria {
+		names[i] = c.Name
+		byName[c.Name] = c
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		c := byName[name]
+		fmt.Fprintf(h, "name:%s\nweight:%g\nexpect:%s\ncheck:%s\njudge:%t\n",
+			c.Name, c.Weight, c.Expect, c.Check, c.Judge)
+		if c.Judge && c.Prompt != "" {
+			data, err := os.ReadFile(filepath.Join(projectRoot, c.Prompt))
+			if err != nil {
+				return "", fmt.Errorf("eval: rubric fingerprint: reading %s: %w", c.Prompt, err)
+			}
+			fmt.Fprintf(h, "prompt:%s:", c.Prompt)
+			h.Write(data)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))[:8], nil
+}
+
 func CreateWorktree(ctx context.Context, projectRoot, ref, caseName string) (string, error) {
 	tmpDir, err := os.MkdirTemp("", "orc-eval-"+caseName+"-")
 	if err != nil {
@@ -321,9 +351,10 @@ type RunResult struct {
 
 // HistoryEntry holds one eval run's summary.
 type HistoryEntry struct {
-	Timestamp         string                      `json:"timestamp"`
-	ConfigFingerprint string                      `json:"config_fingerprint"`
-	Cases             map[string]CaseHistoryEntry `json:"cases"`
+	Timestamp          string                      `json:"timestamp"`
+	ConfigFingerprint  string                      `json:"config_fingerprint"`
+	Cases              map[string]CaseHistoryEntry `json:"cases"`
+	RubricFingerprints map[string]string           `json:"rubric_fingerprints,omitempty"`
 }
 
 // CaseHistoryEntry holds the persisted result for one case.
@@ -332,6 +363,7 @@ type CaseHistoryEntry struct {
 	CostUSD         float64            `json:"cost_usd"`
 	DurationSeconds float64            `json:"duration_seconds"`
 	Details         map[string]float64 `json:"details"`
+	RegradedFrom    string             `json:"regraded_from,omitempty"`
 }
 
 // History holds all historical eval runs.
@@ -457,9 +489,10 @@ func SaveHistory(projectRoot string, h *History) error {
 // AppendResult adds a new history entry from the given case results.
 func (h *History) AppendResult(fingerprint string, cases []CaseResult) {
 	entry := HistoryEntry{
-		Timestamp:         time.Now().UTC().Format(time.RFC3339),
-		ConfigFingerprint: fingerprint,
-		Cases:             make(map[string]CaseHistoryEntry),
+		Timestamp:          time.Now().UTC().Format(time.RFC3339),
+		ConfigFingerprint:  fingerprint,
+		Cases:              make(map[string]CaseHistoryEntry),
+		RubricFingerprints: make(map[string]string),
 	}
 	for _, c := range cases {
 		entry.Cases[c.Name] = CaseHistoryEntry{
@@ -467,6 +500,10 @@ func (h *History) AppendResult(fingerprint string, cases []CaseResult) {
 			CostUSD:         c.CostUSD,
 			DurationSeconds: c.DurationSeconds,
 			Details:         c.Details,
+			RegradedFrom:    c.RegradedFrom,
+		}
+		if c.RubricFingerprint != "" {
+			entry.RubricFingerprints[c.Name] = c.RubricFingerprint
 		}
 	}
 	h.Runs = append(h.Runs, entry)
@@ -536,6 +573,8 @@ func (e *evalRunner) runCase(ctx context.Context, caseName string) (CaseResult, 
 	if runResult.Err != nil {
 		result.WorkflowErr = runResult.Err.Error()
 	}
+	rubricFP, _ := RubricFingerprint(rubric, caseDir, e.projectRoot)
+	result.RubricFingerprint = rubricFP
 	return result, nil
 }
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -28,6 +28,7 @@ import (
 type Fixture struct {
 	Ref         string            `yaml:"ref"`
 	Ticket      string            `yaml:"ticket"`
+	Spec        string            `yaml:"spec"`
 	Vars        map[string]string `yaml:"vars"`
 	Description string            `yaml:"description"`
 }
@@ -86,6 +87,12 @@ func LoadFixture(caseDir string) (*Fixture, error) {
 	}
 	if f.Ticket != filepath.Base(f.Ticket) {
 		return nil, fmt.Errorf("eval: fixture.yaml: ticket %q must not contain path separators", f.Ticket)
+	}
+	if f.Spec == "" {
+		return nil, fmt.Errorf("eval: fixture.yaml: spec is required")
+	}
+	if f.Spec != filepath.Base(f.Spec) {
+		return nil, fmt.Errorf("eval: fixture.yaml: spec %q must not contain path separators", f.Spec)
 	}
 	if !refRegex.MatchString(f.Ref) {
 		return nil, fmt.Errorf("eval: fixture.yaml: ref %q contains invalid characters", f.Ref)

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -692,6 +692,9 @@ func persistRunArtifacts(projectRoot, workflowName, ticket, worktreePath, runID 
 		return fmt.Errorf("eval: persistRunArtifacts: creating history dir: %w", err)
 	}
 	if err := state.CopyTree(src, dst); err != nil {
+		// Remove the partial copy so a later --regrade can't grade an incomplete
+		// run (mirrors state.ArchiveRun's cleanup of a half-written archive).
+		os.RemoveAll(dst)
 		return fmt.Errorf("eval: persistRunArtifacts: copying run %q: %w", runID, err)
 	}
 	return nil

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -638,3 +638,95 @@ func RunEval(ctx context.Context, projectRoot, configPath, workflowName string, 
 
 	return fingerprint, results, nil
 }
+
+// resolveRunArtifactsDir returns the artifacts dir for a saved run. If runID is
+// empty, returns the most recent history entry. Errors if the named run or any
+// history is absent.
+func resolveRunArtifactsDir(artifactsDir, runID string) (string, error) {
+	if runID == "" {
+		latest, err := state.LatestHistoryDir(artifactsDir)
+		if err != nil {
+			return "", fmt.Errorf("eval: locating latest run: %w", err)
+		}
+		if latest == "" {
+			return "", fmt.Errorf("eval: no saved runs found under %s", state.HistoryDir(artifactsDir))
+		}
+		return latest, nil
+	}
+	dir := filepath.Join(state.HistoryDir(artifactsDir), runID)
+	if !state.HasState(dir) {
+		return "", fmt.Errorf("eval: run not found: %q under %s", runID, state.HistoryDir(artifactsDir))
+	}
+	return dir, nil
+}
+
+// RegradeEval re-scores a saved run's artifacts against the current rubric,
+// without re-running the workflow. Appends a history row marked RegradedFrom.
+func RegradeEval(ctx context.Context, projectRoot, configPath, workflowName string, cfg *config.Config, caseName, runID string) (string, []CaseResult, error) {
+	if caseName == "" {
+		return "", nil, fmt.Errorf("eval: --regrade requires a case name")
+	}
+	cdir := caseDirFor(projectRoot, caseName)
+	fixture, err := LoadFixture(cdir)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: loading fixture for %q: %w", caseName, err)
+	}
+	rubric, err := LoadRubric(cdir, projectRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: loading rubric for %q: %w", caseName, err)
+	}
+
+	baseArtifacts := state.ArtifactsDirForWorkflow(projectRoot, workflowName, fixture.Ticket)
+	runDir, err := resolveRunArtifactsDir(baseArtifacts, runID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
+	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runDir, projectRoot, expandedVars)
+	if rubricErr != nil {
+		fmt.Fprintf(os.Stderr, "  warning: rubric evaluation error for %q: %v\n", caseName, rubricErr)
+	}
+	score := ComputeScore(criterionResults, rubric)
+
+	details := make(map[string]float64)
+	var failures []string
+	passCount := 0
+	for _, cr := range criterionResults {
+		details[cr.Name] = cr.Score
+		if cr.Pass {
+			passCount++
+		} else {
+			failures = append(failures, cr.Name+": "+cr.Detail)
+		}
+	}
+	rubricFP, _ := RubricFingerprint(rubric, cdir, projectRoot)
+
+	result := CaseResult{
+		Name:              caseName,
+		Score:             score,
+		PassCount:         passCount,
+		TotalCount:        len(criterionResults),
+		Failures:          failures,
+		Details:           details,
+		RubricFingerprint: rubricFP,
+		RegradedFrom:      filepath.Base(runDir),
+	}
+
+	fingerprint, err := ConfigFingerprint(configPath, cfg, projectRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("eval: computing fingerprint: %w", err)
+	}
+	results := []CaseResult{result}
+
+	history, err := LoadHistory(projectRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: cannot load eval history, skipping save: %v\n", err)
+	} else {
+		history.AppendResult(fingerprint, results)
+		if err := SaveHistory(projectRoot, history); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: failed to save eval history: %v\n", err)
+		}
+	}
+	return fingerprint, results, nil
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -497,7 +497,8 @@ func (e *evalRunner) runCase(ctx context.Context, caseName string) (CaseResult, 
 	}
 
 	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, fixture.Vars)
-	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, worktreePath, e.projectRoot)
+	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
+	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, e.projectRoot, expandedVars)
 	if rubricErr != nil {
 		fmt.Fprintf(os.Stderr, "  warning: rubric evaluation error for %q: %v\n", caseName, rubricErr)
 	}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -339,10 +339,33 @@ type History struct {
 	Runs []HistoryEntry `json:"runs"`
 }
 
+// buildEvalEnv returns the child env for an eval run: inherited env minus
+// CLAUDECODE/ORC_*, plus fixture vars (KEY and ORC_KEY), plus the eval-mode
+// contract (ORC_EVAL, ORC_SPEC_FILE).
+func buildEvalEnv(specFile string, vars map[string]string) []string {
+	env := make([]string, 0, len(os.Environ())+len(vars)*2+2)
+	for _, kv := range os.Environ() {
+		idx := strings.IndexByte(kv, '=')
+		if idx < 0 {
+			continue
+		}
+		key := kv[:idx]
+		if strings.HasPrefix(key, "CLAUDECODE") || strings.HasPrefix(key, "ORC_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	for k, v := range vars {
+		env = append(env, k+"="+v, "ORC_"+k+"="+v)
+	}
+	env = append(env, "ORC_EVAL=1", "ORC_SPEC_FILE="+specFile)
+	return env
+}
+
 // RunWorkflow executes orc in the given worktree and returns the result.
 // It never returns a non-nil error — partial results are always returned
 // so the rubric evaluator can still run.
-func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName string, vars map[string]string) (*RunResult, error) {
+func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName, specFile string, vars map[string]string) (*RunResult, error) {
 	orcBinary, err := os.Executable()
 	if err != nil {
 		return &RunResult{Status: "failed", Err: fmt.Errorf("eval: os.Executable: %w", err)}, nil
@@ -357,24 +380,7 @@ func RunWorkflow(ctx context.Context, worktreePath, ticket, workflowName string,
 	cmd.WaitDelay = 5 * time.Second
 	cmd.Dir = worktreePath
 
-	// Build env: inherit, strip CLAUDECODE/ORC_*, add fixture vars
-	env := make([]string, 0, len(os.Environ())+len(vars)*2)
-	for _, kv := range os.Environ() {
-		idx := strings.IndexByte(kv, '=')
-		if idx < 0 {
-			continue
-		}
-		key := kv[:idx]
-		if strings.HasPrefix(key, "CLAUDECODE") || strings.HasPrefix(key, "ORC_") {
-			continue
-		}
-		env = append(env, kv)
-	}
-	for k, v := range vars {
-		env = append(env, k+"="+v)
-		env = append(env, "ORC_"+k+"="+v)
-	}
-	cmd.Env = env
+	cmd.Env = buildEvalEnv(specFile, vars)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -492,11 +498,12 @@ func (e *evalRunner) runCase(ctx context.Context, caseName string) (CaseResult, 
 	}
 	defer RemoveWorktree(e.projectRoot, worktreePath) //nolint:errcheck
 
-	if err := copyOrcDir(e.projectRoot, worktreePath, e.configPath, e.cfg); err != nil {
-		return CaseResult{Name: caseName}, fmt.Errorf("eval: copying .orc for %q: %w", caseName, err)
+	specFile, err := BuildStage(ctx, e.projectRoot, worktreePath, e.configPath, e.cfg, fixture, caseName)
+	if err != nil {
+		return CaseResult{Name: caseName}, fmt.Errorf("eval: building stage for %q: %w", caseName, err)
 	}
 
-	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, fixture.Vars)
+	runResult, _ := RunWorkflow(ctx, worktreePath, fixture.Ticket, e.workflowName, specFile, fixture.Vars)
 	expandedVars := expandFixtureVars(fixture.Vars, sortedKeys(fixture.Vars))
 	criterionResults, rubricErr := EvaluateRubric(ctx, rubric, runResult.ArtifactsDir, e.projectRoot, expandedVars)
 	if rubricErr != nil {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -91,6 +91,10 @@ func LoadFixture(caseDir string) (*Fixture, error) {
 	if f.Spec == "" {
 		return nil, fmt.Errorf("eval: fixture.yaml: spec is required")
 	}
+	// Path traversal check: spec must be a simple filename, not a path
+	if f.Spec == ".." || f.Spec == "." {
+		return nil, fmt.Errorf("eval: fixture.yaml: spec %q is not allowed", f.Spec)
+	}
 	if f.Spec != filepath.Base(f.Spec) {
 		return nil, fmt.Errorf("eval: fixture.yaml: spec %q must not contain path separators", f.Spec)
 	}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1110,3 +1110,40 @@ func TestRubricFingerprint_ChangesWithJudgePrompt(t *testing.T) {
 		t.Error("rubric fingerprint should change when judge prompt content changes")
 	}
 }
+
+func TestResolveRunArtifactsDir(t *testing.T) {
+	// Build an artifacts tree with two history runs; resolveRunArtifactsDir
+	// returns the named one, and the latest when runID is empty.
+	base := t.TempDir()
+	mk := func(runID string) {
+		d := filepath.Join(base, "history", runID)
+		writeFile(t, filepath.Join(d, "state.json"),
+			`{"ticket":"T-1","status":"completed","phases":{}}`)
+	}
+	mk("2026-01-01T10-00-00.000")
+	mk("2026-01-02T10-00-00.000")
+
+	got, err := resolveRunArtifactsDir(base, "2026-01-01T10-00-00.000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got) != "2026-01-01T10-00-00.000" {
+		t.Errorf("named run = %q, want the 01-01 dir", got)
+	}
+
+	latest, err := resolveRunArtifactsDir(base, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(latest) != "2026-01-02T10-00-00.000" {
+		t.Errorf("latest run = %q, want the 01-02 dir", latest)
+	}
+
+	_, err = resolveRunArtifactsDir(base, "nonexistent-run")
+	if err == nil {
+		t.Fatal("expected error for nonexistent run id")
+	}
+	if !strings.Contains(err.Error(), "run not found") {
+		t.Errorf("error = %v, want 'run not found'", err)
+	}
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1056,3 +1056,20 @@ func TestRunWorkflow_FallbackToHistory(t *testing.T) {
 		t.Errorf("TotalElapsed = %v, want > 0", timing.TotalElapsed())
 	}
 }
+
+func TestRunWorkflow_SetsEvalEnv(t *testing.T) {
+	// We can't run a real `orc run` here, but we can assert the env-building
+	// helper sets ORC_EVAL and ORC_SPEC_FILE. Extracted as buildEvalEnv.
+	env := buildEvalEnv("/stage/.orc/eval-spec/spec.md", map[string]string{"K": "v"})
+	joined := strings.Join(env, "\n")
+	for _, want := range []string{
+		"ORC_EVAL=1",
+		"ORC_SPEC_FILE=/stage/.orc/eval-spec/spec.md",
+		"K=v",
+		"ORC_K=v",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("env missing %q", want)
+		}
+	}
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -690,6 +690,22 @@ func TestLoadFixture_VarShadowsArtifactsDir(t *testing.T) {
 	}
 }
 
+func TestLoadFixture_VarShadowsSystemEnv(t *testing.T) {
+	dangerous := []string{"PATH", "HOME", "IFS", "SHELL", "LD_PRELOAD", "LD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES"}
+	for _, key := range dangerous {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "fixture.yaml"),
+			"ref: abc123\nticket: T-001\nspec: spec.md\nvars:\n  "+key+": x\n")
+		_, err := LoadFixture(dir)
+		if err == nil {
+			t.Fatalf("expected error for var %q shadowing a critical env var", key)
+		}
+		if !strings.Contains(err.Error(), "shadows a critical environment variable") {
+			t.Errorf("var %q: error = %v, want message containing 'shadows a critical environment variable'", key, err)
+		}
+	}
+}
+
 func TestLoadRubric_JudgePromptNotFound(t *testing.T) {
 	dir := t.TempDir()
 	projectRoot := t.TempDir()
@@ -1074,6 +1090,62 @@ func TestRunWorkflow_SetsEvalEnv(t *testing.T) {
 	}
 }
 
+// TestExpandFixtureVars_SymmetricRunAndGrader proves W3: the SAME expanded var
+// map is what flows to both the workflow run env (buildEvalEnv) and the grader,
+// so a var-in-var value resolves identically on both sides — no asymmetry where
+// the workflow sees raw "$LIVE_ROOT/t" but the grader sees "/x/t".
+func TestExpandFixtureVars_SymmetricRunAndGrader(t *testing.T) {
+	raw := map[string]string{
+		"LIVE_ROOT":   "/x",
+		"TICKET_FILE": "$LIVE_ROOT/t",
+	}
+	expanded := expandFixtureVars(raw, sortedKeys(raw))
+	if expanded["TICKET_FILE"] != "/x/t" {
+		t.Fatalf("expandFixtureVars TICKET_FILE = %q, want /x/t", expanded["TICKET_FILE"])
+	}
+
+	// The run env (buildEvalEnv) is fed the SAME expanded map runCase passes to
+	// the grader — assert the resolved value, not the literal "$LIVE_ROOT/t".
+	env := buildEvalEnv("/stage/spec.md", expanded)
+	joined := strings.Join(env, "\n")
+	for _, want := range []string{"TICKET_FILE=/x/t", "ORC_TICKET_FILE=/x/t"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("buildEvalEnv missing %q (asymmetry?); env:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "$LIVE_ROOT/t") {
+		t.Error("buildEvalEnv leaked an unexpanded var-in-var value")
+	}
+}
+
+// TestBuildEvalEnv_StripsInheritedOrcAndClaudecode proves buildEvalEnv removes
+// inherited ORC_* and CLAUDECODE vars before re-adding its own contract, so the
+// eval child starts from a clean orc env.
+func TestBuildEvalEnv_StripsInheritedOrcAndClaudecode(t *testing.T) {
+	t.Setenv("ORC_INHERITED", "leak")
+	t.Setenv("CLAUDECODE", "1")
+	t.Setenv("CLAUDECODE_ENTRYPOINT", "cli")
+
+	env := buildEvalEnv("/stage/spec.md", nil)
+	for _, kv := range env {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if key == "ORC_INHERITED" {
+			t.Errorf("inherited ORC_ var leaked into eval env: %s", kv)
+		}
+		if strings.HasPrefix(key, "CLAUDECODE") {
+			t.Errorf("CLAUDECODE var leaked into eval env: %s", kv)
+		}
+	}
+	// The contract vars are still set.
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "ORC_EVAL=1") || !strings.Contains(joined, "ORC_SPEC_FILE=/stage/spec.md") {
+		t.Errorf("buildEvalEnv missing contract vars; env:\n%s", joined)
+	}
+}
+
 func TestRubricFingerprint_ChangesWithRubric(t *testing.T) {
 	caseDir := t.TempDir()
 	projectRoot := t.TempDir()
@@ -1111,6 +1183,52 @@ func TestRubricFingerprint_ChangesWithJudgePrompt(t *testing.T) {
 	}
 }
 
+func TestRubricFingerprint_Stable(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "judge prompt")
+	r := &Rubric{Criteria: []Criterion{
+		{Name: "tests", Check: "exit 0", Weight: 3, Expect: "exit 0"},
+		{Name: "quality", Judge: true, Prompt: ".orc/p.md", Weight: 2, Expect: ">= 7"},
+	}}
+	fp1, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp2, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 != fp2 {
+		t.Errorf("rubric fingerprint should be stable across calls: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestRubricFingerprint_OrderIndependent(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "judge prompt")
+	r1 := &Rubric{Criteria: []Criterion{
+		{Name: "tests", Check: "exit 0", Weight: 3, Expect: "exit 0"},
+		{Name: "quality", Judge: true, Prompt: ".orc/p.md", Weight: 2, Expect: ">= 7"},
+	}}
+	r2 := &Rubric{Criteria: []Criterion{
+		{Name: "quality", Judge: true, Prompt: ".orc/p.md", Weight: 2, Expect: ">= 7"},
+		{Name: "tests", Check: "exit 0", Weight: 3, Expect: "exit 0"},
+	}}
+	fp1, err := RubricFingerprint(r1, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp2, err := RubricFingerprint(r2, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 != fp2 {
+		t.Errorf("rubric fingerprint should be order-independent: %q vs %q", fp1, fp2)
+	}
+}
+
 func TestResolveRunArtifactsDir(t *testing.T) {
 	// Build an artifacts tree with two history runs; resolveRunArtifactsDir
 	// returns the named one, and the latest when runID is empty.
@@ -1145,5 +1263,150 @@ func TestResolveRunArtifactsDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "run not found") {
 		t.Errorf("error = %v, want 'run not found'", err)
+	}
+}
+
+func TestResolveRunArtifactsDir_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	// Build a state.json one level up from history/ to prove a traversal would
+	// otherwise reach it.
+	writeFile(t, filepath.Join(base, "state.json"),
+		`{"ticket":"T-1","status":"completed","phases":{}}`)
+	for _, bad := range []string{"..", ".", "../../tmp/evil", "sub/run", "a/b"} {
+		_, err := resolveRunArtifactsDir(base, bad)
+		if err == nil {
+			t.Fatalf("expected error for traversal run id %q", bad)
+		}
+		if !strings.Contains(err.Error(), "invalid run id") {
+			t.Errorf("run id %q: error = %v, want 'invalid run id'", bad, err)
+		}
+	}
+}
+
+// TestPersistRunArtifacts_PersistThenResolve proves the B2 fix: an eval run's
+// archived artifacts, written inside the throwaway worktree, are copied to a
+// stable LIVE-project location that --regrade's resolveRunArtifactsDir reads
+// from. The pre-existing TestResolveRunArtifactsDir masks this bug because it
+// hand-builds the tree at the live location.
+func TestPersistRunArtifacts_PersistThenResolve(t *testing.T) {
+	projectRoot := t.TempDir()
+	worktreePath := t.TempDir()
+	workflowName := "bugfix"
+	ticket := "T-001"
+	runID := "2026-01-02T10-00-00.000"
+
+	// Simulate what `orc run` archives INSIDE the worktree.
+	wtArtifacts := state.ArtifactsDirForWorkflow(worktreePath, workflowName, ticket)
+	wtRunDir := filepath.Join(state.HistoryDir(wtArtifacts), runID)
+	writeFile(t, filepath.Join(wtRunDir, "state.json"),
+		`{"ticket":"T-001","status":"completed","phases":{}}`)
+	writeFile(t, filepath.Join(wtRunDir, "costs.json"),
+		`{"phases":[],"total_cost_usd":2.5}`)
+
+	// Before persist, the live location has nothing — resolve must fail.
+	liveArtifacts := state.ArtifactsDirForWorkflow(projectRoot, workflowName, ticket)
+	if _, err := resolveRunArtifactsDir(liveArtifacts, runID); err == nil {
+		t.Fatal("expected resolve to fail before persist")
+	}
+
+	// Persist the run out of the worktree into the live project.
+	if err := persistRunArtifacts(projectRoot, workflowName, ticket, worktreePath, runID); err != nil {
+		t.Fatalf("persistRunArtifacts: %v", err)
+	}
+
+	// Now resolve (by id and latest) must succeed against the live location.
+	got, err := resolveRunArtifactsDir(liveArtifacts, runID)
+	if err != nil {
+		t.Fatalf("resolve by id after persist: %v", err)
+	}
+	if filepath.Base(got) != runID {
+		t.Errorf("resolved run = %q, want run id %q", got, runID)
+	}
+	latest, err := resolveRunArtifactsDir(liveArtifacts, "")
+	if err != nil {
+		t.Fatalf("resolve latest after persist: %v", err)
+	}
+	if filepath.Base(latest) != runID {
+		t.Errorf("resolved latest = %q, want run id %q", latest, runID)
+	}
+	// The copied tree must carry the run's files.
+	costs, err := state.LoadCosts(got)
+	if err != nil || costs == nil || costs.TotalCostUSD != 2.5 {
+		t.Errorf("persisted costs not readable: costs=%v err=%v", costs, err)
+	}
+}
+
+// TestRegradeEval_ReadsPersistedRun proves RegradeEval grades a run that was
+// persisted via persistRunArtifacts (the live location), without re-running the
+// workflow, and records RegradedFrom + a rubric fingerprint.
+func TestRegradeEval_ReadsPersistedRun(t *testing.T) {
+	projectRoot := t.TempDir()
+	workflowName := ""
+	ticket := "T-001"
+	runID := "2026-01-02T10-00-00.000"
+
+	// Eval case: fixture + a script rubric that always passes.
+	caseDir := filepath.Join(projectRoot, ".orc", "evals", "bug-fix")
+	writeFile(t, filepath.Join(caseDir, "fixture.yaml"),
+		"ref: HEAD\nticket: "+ticket+"\nspec: spec.md\n")
+	writeFile(t, filepath.Join(caseDir, "spec.md"), "do it\n")
+	writeFile(t, filepath.Join(caseDir, "rubric.yaml"),
+		"criteria:\n  - name: ok\n    check: \"exit 0\"\n    weight: 1\n")
+	configPath := filepath.Join(projectRoot, ".orc", "config.yaml")
+	writeFile(t, configPath, "phases:\n  - name: p\n    run: \"true\"\n")
+	cfg := &config.Config{Phases: []config.Phase{{Name: "p", Run: "true"}}}
+
+	// Simulate a persisted run at the live location.
+	liveArtifacts := state.ArtifactsDirForWorkflow(projectRoot, workflowName, ticket)
+	liveRunDir := filepath.Join(state.HistoryDir(liveArtifacts), runID)
+	writeFile(t, filepath.Join(liveRunDir, "state.json"),
+		`{"ticket":"T-001","status":"completed","phases":{}}`)
+
+	_, cases, err := RegradeEval(context.Background(), projectRoot, configPath, workflowName, cfg, "bug-fix", runID)
+	if err != nil {
+		t.Fatalf("RegradeEval: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("expected 1 case result, got %d", len(cases))
+	}
+	c := cases[0]
+	if c.RegradedFrom != runID {
+		t.Errorf("RegradedFrom = %q, want %q", c.RegradedFrom, runID)
+	}
+	if c.RubricFingerprint == "" {
+		t.Error("expected a rubric fingerprint to be set")
+	}
+	if c.Score != 100 {
+		t.Errorf("score = %d, want 100 (exit-0 criterion passes)", c.Score)
+	}
+
+	// The regrade row was appended to history.
+	h, err := LoadHistory(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(h.Runs) != 1 {
+		t.Fatalf("expected 1 history run appended, got %d", len(h.Runs))
+	}
+	if got := h.Runs[0].Cases["bug-fix"].RegradedFrom; got != runID {
+		t.Errorf("history RegradedFrom = %q, want %q", got, runID)
+	}
+}
+
+func TestPersistRunArtifacts_EmptyRunID(t *testing.T) {
+	// A failed run (no archived id) is a no-op, not an error.
+	if err := persistRunArtifacts(t.TempDir(), "wf", "T-1", t.TempDir(), ""); err != nil {
+		t.Fatalf("expected no-op for empty run id, got %v", err)
+	}
+}
+
+func TestResolveRunArtifactsDir_NoSavedRuns(t *testing.T) {
+	base := t.TempDir() // no history dir at all
+	_, err := resolveRunArtifactsDir(base, "")
+	if err == nil {
+		t.Fatal("expected error when no saved runs exist")
+	}
+	if !strings.Contains(err.Error(), "no saved runs") {
+		t.Errorf("error = %v, want 'no saved runs'", err)
 	}
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -193,6 +193,19 @@ func TestLoadFixture_SpecPathSeparator(t *testing.T) {
 	}
 }
 
+func TestLoadFixture_SpecDotDot(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"),
+		"ref: abc123\nticket: T-001\nspec: \"..\"\n")
+	_, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatal("expected error for spec '..'")
+	}
+	if !strings.Contains(err.Error(), "is not allowed") {
+		t.Errorf("error = %v, want message containing 'is not allowed'", err)
+	}
+}
+
 // --- LoadRubric ---
 
 func TestLoadRubric(t *testing.T) {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -59,6 +59,7 @@ func TestLoadFixture(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "fixture.yaml"), `
 ref: abc123f
 ticket: T-001
+spec: spec.md
 description: A test case
 vars:
   FOO: bar
@@ -108,7 +109,7 @@ func TestLoadFixture_MissingTicket(t *testing.T) {
 
 func TestLoadFixture_InvalidRef(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "fixture.yaml"), "ref: \"abc; rm -rf /\"\nticket: T-001\n")
+	writeFile(t, filepath.Join(dir, "fixture.yaml"), "ref: \"abc; rm -rf /\"\nticket: T-001\nspec: spec.md\n")
 	_, err := LoadFixture(dir)
 	if err == nil {
 		t.Fatal("expected error for invalid ref")
@@ -148,6 +149,44 @@ func TestLoadFixture_PathSeparatorTicket(t *testing.T) {
 	_, err := LoadFixture(dir)
 	if err == nil {
 		t.Fatal("expected error for ticket with path separator")
+	}
+	if !strings.Contains(err.Error(), "must not contain path separators") {
+		t.Errorf("error = %v, want message containing 'must not contain path separators'", err)
+	}
+}
+
+func TestLoadFixture_Spec(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"),
+		"ref: abc123\nticket: T-001\nspec: spec.md\n")
+	f, err := LoadFixture(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Spec != "spec.md" {
+		t.Errorf("Spec = %q, want spec.md", f.Spec)
+	}
+}
+
+func TestLoadFixture_MissingSpec(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"), "ref: abc123\nticket: T-001\n")
+	_, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatal("expected error for missing spec")
+	}
+	if !strings.Contains(err.Error(), "spec is required") {
+		t.Errorf("error = %v, want message containing 'spec is required'", err)
+	}
+}
+
+func TestLoadFixture_SpecPathSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "fixture.yaml"),
+		"ref: abc123\nticket: T-001\nspec: \"sub/spec.md\"\n")
+	_, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatal("expected error for spec with path separator")
 	}
 	if !strings.Contains(err.Error(), "must not contain path separators") {
 		t.Errorf("error = %v, want message containing 'must not contain path separators'", err)
@@ -467,10 +506,10 @@ func TestRenderCaseList(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".orc", "evals", "bug-fix"), 0o755)
 	writeFile(t, filepath.Join(dir, ".orc", "evals", "bug-fix", "fixture.yaml"),
-		"ref: abc123\nticket: T-001\ndescription: Fix the bug\n")
+		"ref: abc123\nticket: T-001\nspec: spec.md\ndescription: Fix the bug\n")
 	os.MkdirAll(filepath.Join(dir, ".orc", "evals", "feature"), 0o755)
 	writeFile(t, filepath.Join(dir, ".orc", "evals", "feature", "fixture.yaml"),
-		"ref: def456\nticket: T-002\n")
+		"ref: def456\nticket: T-002\nspec: spec.md\n")
 
 	var buf bytes.Buffer
 	if err := RenderCaseList(&buf, dir); err != nil {
@@ -514,7 +553,7 @@ func TestValidateRef(t *testing.T) {
 	validRefs := []string{"abc123f", "main", "v1.0", "HEAD~3"}
 	for _, ref := range validRefs {
 		writeFile(t, filepath.Join(dir, "fixture.yaml"),
-			"ref: "+ref+"\nticket: T-001\n")
+			"ref: "+ref+"\nticket: T-001\nspec: spec.md\n")
 		_, err := LoadFixture(dir)
 		if err != nil {
 			t.Errorf("ref %q should be valid, got error: %v", ref, err)
@@ -524,7 +563,7 @@ func TestValidateRef(t *testing.T) {
 	invalidRefs := []string{";", "|", "`", "$("}
 	for _, ref := range invalidRefs {
 		writeFile(t, filepath.Join(dir, "fixture.yaml"),
-			"ref: \""+ref+"\"\nticket: T-001\n")
+			"ref: \""+ref+"\"\nticket: T-001\nspec: spec.md\n")
 		_, err := LoadFixture(dir)
 		if err == nil {
 			t.Errorf("ref %q should be invalid but got no error", ref)
@@ -615,7 +654,7 @@ func TestLoadFixture_StrictYAML(t *testing.T) {
 func TestLoadFixture_VarShadowsBuiltin(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "fixture.yaml"),
-		"ref: abc123\nticket: T-001\nvars:\n  TICKET: override\n")
+		"ref: abc123\nticket: T-001\nspec: spec.md\nvars:\n  TICKET: override\n")
 	_, err := LoadFixture(dir)
 	if err == nil {
 		t.Fatal("expected error for var overriding built-in")
@@ -628,7 +667,7 @@ func TestLoadFixture_VarShadowsBuiltin(t *testing.T) {
 func TestLoadFixture_VarShadowsArtifactsDir(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "fixture.yaml"),
-		"ref: abc123\nticket: T-001\nvars:\n  ARTIFACTS_DIR: x\n")
+		"ref: abc123\nticket: T-001\nspec: spec.md\nvars:\n  ARTIFACTS_DIR: x\n")
 	_, err := LoadFixture(dir)
 	if err == nil {
 		t.Fatal("expected error for var overriding built-in")

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -831,7 +831,7 @@ func TestRenderHistoryReport(t *testing.T) {
 	var buf bytes.Buffer
 	RenderHistoryReport(&buf, h)
 	out := buf.String()
-	for _, want := range []string{"abc123", "85/100", "Jan 15"} {
+	for _, want := range []string{"abc123", "85/100", "Jan 15", "RUBRIC"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q", want)
 		}
@@ -1071,5 +1071,42 @@ func TestRunWorkflow_SetsEvalEnv(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("env missing %q", want)
 		}
+	}
+}
+
+func TestRubricFingerprint_ChangesWithRubric(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	r1 := &Rubric{Criteria: []Criterion{{Name: "a", Check: "exit 0", Weight: 1}}}
+	fp1, err := RubricFingerprint(r1, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2 := &Rubric{Criteria: []Criterion{{Name: "a", Check: "exit 1", Weight: 1}}}
+	fp2, err := RubricFingerprint(r2, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Error("rubric fingerprint should change when a check changes")
+	}
+}
+
+func TestRubricFingerprint_ChangesWithJudgePrompt(t *testing.T) {
+	caseDir := t.TempDir()
+	projectRoot := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "v1")
+	r := &Rubric{Criteria: []Criterion{{Name: "q", Judge: true, Prompt: ".orc/p.md", Weight: 1}}}
+	fp1, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(projectRoot, ".orc", "p.md"), "v2")
+	fp2, err := RubricFingerprint(r, caseDir, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Error("rubric fingerprint should change when judge prompt content changes")
 	}
 }

--- a/internal/eval/render.go
+++ b/internal/eval/render.go
@@ -65,8 +65,8 @@ func RenderScoreReport(w io.Writer, fingerprint string, cases []CaseResult) {
 // RenderHistoryReport prints a formatted table of historical eval runs.
 func RenderHistoryReport(w io.Writer, history *History) {
 	fmt.Fprintf(w, "\n  %sorc eval --report%s — score history\n\n", ux.Bold, ux.Reset)
-	fmt.Fprintf(w, "  %s%-12s %-13s %-10s %-11s %s%s\n",
-		ux.Dim, "FINGERPRINT", "DATE", "AVG SCORE", "TOTAL COST", "TOTAL TIME", ux.Reset)
+	fmt.Fprintf(w, "  %s%-12s %-10s %-13s %-10s %-11s %s%s\n",
+		ux.Dim, "FINGERPRINT", "RUBRIC", "DATE", "AVG SCORE", "TOTAL COST", "TOTAL TIME", ux.Reset)
 
 	for _, entry := range history.Runs {
 		t, err := time.Parse(time.RFC3339, entry.Timestamp)
@@ -85,15 +85,34 @@ func RenderHistoryReport(w io.Writer, history *History) {
 		if len(entry.Cases) > 0 {
 			avgScore = totalScore / float64(len(entry.Cases))
 		}
+		rubricFP := summarizeRubricFPs(entry.RubricFingerprints)
 		totalDuration := time.Duration(float64(time.Second) * totalDur)
-		fmt.Fprintf(w, "  %-12s %-13s %d/100      $%-10.2f %s\n",
+		fmt.Fprintf(w, "  %-12s %-10s %-13s %d/100      $%-10.2f %s\n",
 			entry.ConfigFingerprint,
+			rubricFP,
 			dateStr,
 			int(math.Round(avgScore)),
 			totalCost,
 			state.FormatDuration(totalDuration),
 		)
 	}
+}
+
+// summarizeRubricFPs renders the rubric fingerprints for a history row: the
+// single value if all cases share it, "-" if none, else "mixed".
+func summarizeRubricFPs(m map[string]string) string {
+	if len(m) == 0 {
+		return "-"
+	}
+	var first string
+	for _, v := range m {
+		if first == "" {
+			first = v
+		} else if v != first {
+			return "mixed"
+		}
+	}
+	return first
 }
 
 // RenderJSON writes eval results as JSON to w.

--- a/internal/eval/rubric.go
+++ b/internal/eval/rubric.go
@@ -37,6 +37,9 @@ type CaseResult struct {
 	Failures        []string           `json:"failures,omitempty"`
 	Details         map[string]float64 `json:"details"`
 	WorkflowErr     string             `json:"workflow_err,omitempty"`
+
+	RubricFingerprint string `json:"rubric_fingerprint,omitempty"`
+	RegradedFrom      string `json:"regraded_from,omitempty"`
 }
 
 var scoreRegex = regexp.MustCompile(`SCORE:\s*(\d+)`)

--- a/internal/eval/rubric.go
+++ b/internal/eval/rubric.go
@@ -65,9 +65,11 @@ func filteredEnv(extras ...string) []string {
 	return append(env, extras...)
 }
 
-// expandFixtureVars expands var-in-var references in declaration order, so a
-// later var like "$FIRST/leaf" resolves against earlier vars. Order is the
-// fixture's var key order.
+// expandFixtureVars expands var-in-var references following the given order, so
+// a var like "$FIRST/leaf" resolves against vars expanded earlier in that order.
+// Production callers pass sortedKeys (alphabetical), since Fixture.Vars is an
+// unordered map and cannot preserve YAML declaration order — so a var that
+// references another must sort after its dependency to resolve.
 func expandFixtureVars(vars map[string]string, order []string) map[string]string {
 	result := make(map[string]string, len(vars))
 	lookup := make(map[string]string, len(vars))

--- a/internal/eval/rubric.go
+++ b/internal/eval/rubric.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -61,8 +62,56 @@ func filteredEnv(extras ...string) []string {
 	return append(env, extras...)
 }
 
-// EvaluateRubric runs all criteria in the rubric and returns results.
-func EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, worktreePath, projectRoot string) ([]CriterionResult, error) {
+// expandFixtureVars expands var-in-var references in declaration order, so a
+// later var like "$FIRST/leaf" resolves against earlier vars. Order is the
+// fixture's var key order.
+func expandFixtureVars(vars map[string]string, order []string) map[string]string {
+	result := make(map[string]string, len(vars))
+	lookup := make(map[string]string, len(vars))
+	for _, k := range order {
+		v, ok := vars[k]
+		if !ok {
+			continue
+		}
+		expanded := dispatch.ExpandVars(v, lookup)
+		result[k] = expanded
+		lookup[k] = expanded
+	}
+	// Include any keys not present in order (defensive), unexpanded.
+	for k, v := range vars {
+		if _, done := result[k]; !done {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// sortedKeys returns the keys of m in alphabetical order. Production callers
+// use this to give expandFixtureVars a deterministic order, since
+// Fixture.Vars is an unordered map and cannot preserve YAML declaration order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// EvaluateRubric runs all criteria against the run's artifacts. Grader
+// subprocesses run with cwd = projectRoot and receive the fixture vars
+// (as KEY and ORC_KEY); paths resolve from the live project.
+func EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, projectRoot string, vars map[string]string) ([]CriterionResult, error) {
+	varEnv := make([]string, 0, len(vars)*2)
+	for k, v := range vars {
+		varEnv = append(varEnv, k+"="+v, "ORC_"+k+"="+v)
+	}
+	baseExtras := append([]string{
+		"ARTIFACTS_DIR=" + artifactsDir,
+		"WORK_DIR=" + projectRoot,
+		"PROJECT_ROOT=" + projectRoot,
+	}, varEnv...)
+
 	var results []CriterionResult
 	for _, c := range rubric.Criteria {
 		if ctx.Err() != nil {
@@ -71,8 +120,8 @@ func EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, worktreeP
 
 		if c.Check != "" {
 			cmd := exec.CommandContext(ctx, "bash", "-c", c.Check)
-			cmd.Dir = worktreePath
-			cmd.Env = filteredEnv("ARTIFACTS_DIR="+artifactsDir, "WORK_DIR="+worktreePath, "PROJECT_ROOT="+projectRoot)
+			cmd.Dir = projectRoot
+			cmd.Env = filteredEnv(baseExtras...)
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
 			cmd.WaitDelay = 5 * time.Second
@@ -108,8 +157,8 @@ func EvaluateRubric(ctx context.Context, rubric *Rubric, artifactsDir, worktreeP
 				continue
 			}
 			cmd := exec.CommandContext(ctx, "claude", "-p", "--model", "sonnet", "--output-format", "text")
-			cmd.Dir = worktreePath
-			cmd.Env = filteredEnv("ARTIFACTS_DIR="+artifactsDir, "WORK_DIR="+worktreePath, "PROJECT_ROOT="+projectRoot)
+			cmd.Dir = projectRoot
+			cmd.Env = filteredEnv(baseExtras...)
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
 			cmd.WaitDelay = 5 * time.Second

--- a/internal/eval/rubric_test.go
+++ b/internal/eval/rubric_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -85,7 +86,7 @@ func TestEvaluateRubric_ScriptPass(t *testing.T) {
 		{Name: "exits-zero", Check: "true", Expect: "exit 0", Weight: 1},
 	}}
 	dir := t.TempDir()
-	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, dir)
+	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestEvaluateRubric_ScriptFail_WrongExitCode(t *testing.T) {
 		{Name: "exits-zero", Check: "false", Expect: "exit 0", Weight: 1},
 	}}
 	dir := t.TempDir()
-	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, dir)
+	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestEvaluateRubric_ScriptPass_ExpectedNonzeroExit(t *testing.T) {
 		{Name: "expects-2", Check: "exit 2", Expect: "exit 2", Weight: 1},
 	}}
 	dir := t.TempDir()
-	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, dir)
+	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +139,7 @@ func TestEvaluateRubric_ContextCancelledBeforeRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	results, err := EvaluateRubric(ctx, rubric, dir, dir, dir)
+	results, err := EvaluateRubric(ctx, rubric, dir, dir, nil)
 	if err == nil {
 		t.Fatal("expected ctx error, got nil")
 	}
@@ -159,7 +160,7 @@ func TestEvaluateRubric_ContextCancelledMidRun(t *testing.T) {
 	time.AfterFunc(100*time.Millisecond, cancel)
 
 	start := time.Now()
-	results, err := EvaluateRubric(ctx, rubric, dir, dir, dir)
+	results, err := EvaluateRubric(ctx, rubric, dir, dir, nil)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -180,7 +181,7 @@ func TestEvaluateRubric_ContextCancelledMidRun(t *testing.T) {
 func TestEvaluateRubric_EmptyRubric(t *testing.T) {
 	rubric := &Rubric{Criteria: nil}
 	dir := t.TempDir()
-	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, dir)
+	results, err := EvaluateRubric(context.Background(), rubric, dir, dir, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,5 +208,74 @@ func TestScoreRegex_NoMatch(t *testing.T) {
 	matches := scoreRegex.FindAllStringSubmatch(output, -1)
 	if len(matches) != 0 {
 		t.Fatalf("got %d matches, want 0", len(matches))
+	}
+}
+
+func TestEvaluateRubric_CheckSeesVars(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "uses-var", Check: `test "$MYVAR" = "hello"`, Expect: "exit 0", Weight: 1},
+	}}
+	vars := map[string]string{"MYVAR": "hello"}
+
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || !results[0].Pass {
+		t.Errorf("check should see MYVAR=hello and pass; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_CheckSeesORCPrefixedVar(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "orc-prefixed", Check: `test "$ORC_MYVAR" = "hi"`, Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot,
+		map[string]string{"MYVAR": "hi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("check should see ORC_MYVAR=hi; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_VarInVarExpansion(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	// SECOND references FIRST; it must arrive expanded.
+	vars := expandFixtureVars(map[string]string{
+		"FIRST":  "/base",
+		"SECOND": "$FIRST/leaf",
+	}, []string{"FIRST", "SECOND"})
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "expanded", Check: `test "$SECOND" = "/base/leaf"`, Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("SECOND should expand to /base/leaf; got %+v", results)
+	}
+}
+
+func TestEvaluateRubric_CheckRunsFromProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactsDir := t.TempDir()
+	writeFile(t, filepath.Join(projectRoot, "marker.txt"), "x")
+	rubric := &Rubric{Criteria: []Criterion{
+		{Name: "cwd", Check: "test -f marker.txt", Expect: "exit 0", Weight: 1},
+	}}
+	results, err := EvaluateRubric(context.Background(), rubric, artifactsDir, projectRoot, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("check should run with cwd=projectRoot; got %+v", results)
 	}
 }

--- a/internal/eval/stage.go
+++ b/internal/eval/stage.go
@@ -1,0 +1,135 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/jorge-barreto/orc/internal/config"
+)
+
+// SpecStagePath is the worktree-relative path where the case spec is written.
+// The workflow finds it via $ORC_SPEC_FILE (its absolute form).
+const SpecStagePath = ".orc/eval-spec/spec.md"
+
+// caseDirFor returns the eval case directory for a given case name.
+// Named caseDirFor (not caseDir) to avoid colliding with the local
+// variable `caseDir` inside runCase.
+func caseDirFor(projectRoot, caseName string) string {
+	return filepath.Join(projectRoot, ".orc", "evals", caseName)
+}
+
+// BuildStage curates an existing worktree (already checked out at fixture.Ref)
+// into the agent's stage and commits it so the tree is git-clean:
+//   - copies the case spec to SpecStagePath,
+//   - removes .orc/evals (holds the grader out of the agent's environment),
+//   - writes the live workflow + prompt files over the ref's copies,
+//   - gitignores orc's runtime dirs so the run doesn't re-dirty the tree,
+//   - commits everything.
+//
+// Returns the absolute path of the spec on the stage.
+func BuildStage(ctx context.Context, projectRoot, worktreePath, configPath string, cfg *config.Config, fixture *Fixture, caseName string) (string, error) {
+	// (a) copy the spec onto the stage
+	specSrc := filepath.Join(caseDirFor(projectRoot, caseName), fixture.Spec)
+	specDst := filepath.Join(worktreePath, SpecStagePath)
+	if err := os.MkdirAll(filepath.Dir(specDst), 0o755); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: creating eval-spec dir: %w", err)
+	}
+	if err := copyFile(specSrc, specDst); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: copying spec: %w", err)
+	}
+
+	// (b) remove .orc/evals — the grader must not be on the agent's stage
+	if err := os.RemoveAll(filepath.Join(worktreePath, ".orc", "evals")); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: removing .orc/evals: %w", err)
+	}
+
+	// (c) write the live workflow + prompt files over the ref's copies
+	if err := copyOrcDir(projectRoot, worktreePath, configPath, cfg); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: writing live workflow: %w", err)
+	}
+
+	// (d) gitignore orc's runtime dirs so the run stays clean
+	if err := appendGitignore(worktreePath, ".orc/artifacts/", ".orc/audit/"); err != nil {
+		return "", fmt.Errorf("eval: BuildStage: writing .gitignore: %w", err)
+	}
+
+	// (e) commit the curated stage
+	if err := gitCommitStage(ctx, worktreePath); err != nil {
+		return "", err
+	}
+	return specDst, nil
+}
+
+// appendGitignore appends entries to the worktree's root .gitignore, creating it
+// if absent and avoiding duplicate lines.
+func appendGitignore(worktreePath string, entries ...string) error {
+	path := filepath.Join(worktreePath, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	have := map[string]bool{}
+	for _, line := range splitLines(string(existing)) {
+		have[line] = true
+	}
+	out := string(existing)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out += "\n"
+	}
+	for _, e := range entries {
+		if !have[e] {
+			out += e + "\n"
+		}
+	}
+	return os.WriteFile(path, []byte(out), 0o644)
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// gitCommitStage runs `git add -A && git commit` in the worktree with an
+// identity that does not depend on the user's git config.
+func gitCommitStage(ctx context.Context, worktreePath string) error {
+	add := exec.CommandContext(ctx, "git", "add", "-A")
+	add.Dir = worktreePath
+	setProcAttrs(add)
+	if out, err := add.CombinedOutput(); err != nil {
+		return fmt.Errorf("eval: BuildStage: git add: %w\n%s", err, out)
+	}
+	commit := exec.CommandContext(ctx, "git",
+		"-c", "user.email=orc-eval@localhost",
+		"-c", "user.name=orc eval",
+		"-c", "commit.gpgsign=false",
+		"commit", "-q", "-m", "orc eval stage",
+	)
+	commit.Dir = worktreePath
+	setProcAttrs(commit)
+	if out, err := commit.CombinedOutput(); err != nil {
+		return fmt.Errorf("eval: BuildStage: git commit: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// setProcAttrs applies the standard process-group settings used across eval.
+func setProcAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
+	cmd.WaitDelay = 5 * time.Second
+}

--- a/internal/eval/stage.go
+++ b/internal/eval/stage.go
@@ -117,7 +117,12 @@ func gitCommitStage(ctx context.Context, worktreePath string) error {
 		"-c", "user.email=orc-eval@localhost",
 		"-c", "user.name=orc eval",
 		"-c", "commit.gpgsign=false",
-		"commit", "-q", "-m", "orc eval stage",
+		// --no-verify: the curation commit is disposable scaffolding; worktrees
+		// share .git/hooks, so a project pre-commit/commit-msg hook would
+		// otherwise fire on it and could abort the eval.
+		// --allow-empty: tolerate the rare "nothing to commit" case (curation
+		// produced no net change) instead of failing the whole eval.
+		"commit", "--no-verify", "--allow-empty", "-q", "-m", "orc eval stage",
 	)
 	commit.Dir = worktreePath
 	setProcAttrs(commit)

--- a/internal/eval/stage_test.go
+++ b/internal/eval/stage_test.go
@@ -57,6 +57,48 @@ func gitStatusPorcelain(t *testing.T, dir string) string {
 	return string(out)
 }
 
+// TestBuildStage_SkipsGitHooks proves W1: a project pre-commit hook (shared by
+// worktrees via .git/hooks) must NOT abort the throwaway curation commit, so
+// BuildStage passes --no-verify.
+func TestBuildStage_SkipsGitHooks(t *testing.T) {
+	repo := t.TempDir()
+	initGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, ".orc", "config.yaml"),
+		"phases:\n  - name: p\n    prompt: .orc/prompts/p.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "prompts", "p.md"), "REF VERSION")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "fixture.yaml"),
+		"ref: HEAD\nticket: T-1\nspec: spec.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "spec.md"), "BUILD THE THING")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "rubric.yaml"),
+		"criteria:\n  - name: c\n    check: \"exit 0\"\n    weight: 1\n")
+	ref := gitCommitAll(t, repo, "init")
+
+	// Install a pre-commit hook that always fails. Worktrees share .git/hooks,
+	// so without --no-verify this would abort the curation commit.
+	hook := filepath.Join(repo, ".git", "hooks", "pre-commit")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\necho 'hook says no' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Phases: []config.Phase{{Name: "p", Prompt: ".orc/prompts/p.md"}}}
+	fixture := &Fixture{Ref: ref, Ticket: "T-1", Spec: "spec.md"}
+
+	wt, err := CreateWorktree(context.Background(), repo, ref, "bug-fix")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	defer RemoveWorktree(repo, wt)
+
+	if _, err := BuildStage(context.Background(), repo, wt,
+		filepath.Join(repo, ".orc", "config.yaml"), cfg, fixture, "bug-fix"); err != nil {
+		t.Fatalf("BuildStage failed (pre-commit hook should be skipped): %v", err)
+	}
+	if s := gitStatusPorcelain(t, wt); s != "" {
+		t.Errorf("worktree not clean after BuildStage:\n%s", s)
+	}
+}
+
 func TestBuildStage(t *testing.T) {
 	repo := t.TempDir()
 	initGitRepo(t, repo)

--- a/internal/eval/stage_test.go
+++ b/internal/eval/stage_test.go
@@ -1,0 +1,122 @@
+package eval
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jorge-barreto/orc/internal/config"
+)
+
+// initGitRepo creates a git repo at dir with one commit and returns nothing.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func gitCommitAll(t *testing.T, dir, msg string) string {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", msg}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitStatusPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	return string(out)
+}
+
+func TestBuildStage(t *testing.T) {
+	repo := t.TempDir()
+	initGitRepo(t, repo)
+
+	// Project files at the ref: a workflow config, a prompt, an eval case (with grader).
+	writeFile(t, filepath.Join(repo, ".orc", "config.yaml"),
+		"phases:\n  - name: p\n    prompt: .orc/prompts/p.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "prompts", "p.md"), "REF VERSION")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "fixture.yaml"),
+		"ref: HEAD\nticket: T-1\nspec: spec.md\n")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "spec.md"), "BUILD THE THING")
+	writeFile(t, filepath.Join(repo, ".orc", "evals", "bug-fix", "rubric.yaml"),
+		"criteria:\n  - name: c\n    check: \"exit 0\"\n    weight: 1\n")
+	ref := gitCommitAll(t, repo, "init")
+
+	// Live edit: the prompt differs from the committed ref version (this is what
+	// today's injection makes "dirty"; the curation commit must absorb it).
+	writeFile(t, filepath.Join(repo, ".orc", "prompts", "p.md"), "LIVE VERSION")
+
+	cfg := &config.Config{Phases: []config.Phase{{Name: "p", Prompt: ".orc/prompts/p.md"}}}
+	fixture := &Fixture{Ref: ref, Ticket: "T-1", Spec: "spec.md"}
+
+	wt, err := CreateWorktree(context.Background(), repo, ref, "bug-fix")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	defer RemoveWorktree(repo, wt)
+
+	specAbs, err := BuildStage(context.Background(), repo, wt,
+		filepath.Join(repo, ".orc", "config.yaml"), cfg, fixture, "bug-fix")
+	if err != nil {
+		t.Fatalf("BuildStage: %v", err)
+	}
+
+	// (1) tree is clean
+	if s := gitStatusPorcelain(t, wt); s != "" {
+		t.Errorf("worktree not clean after BuildStage:\n%s", s)
+	}
+	// (2) grader/evals dir is gone
+	if _, err := os.Stat(filepath.Join(wt, ".orc", "evals")); !os.IsNotExist(err) {
+		t.Errorf(".orc/evals should be absent from stage, stat err = %v", err)
+	}
+	// (3) spec copied to the known path; returned path matches; contents correct
+	wantSpec := filepath.Join(wt, SpecStagePath)
+	if specAbs != wantSpec {
+		t.Errorf("specAbs = %q, want %q", specAbs, wantSpec)
+	}
+	data, err := os.ReadFile(specAbs)
+	if err != nil || string(data) != "BUILD THE THING" {
+		t.Errorf("spec contents = %q (err %v), want 'BUILD THE THING'", data, err)
+	}
+	// (4) live prompt present (not the ref version)
+	pd, _ := os.ReadFile(filepath.Join(wt, ".orc", "prompts", "p.md"))
+	if string(pd) != "LIVE VERSION" {
+		t.Errorf("prompt = %q, want LIVE VERSION", pd)
+	}
+	// (5) artifacts/audit are gitignored: creating them keeps the tree clean
+	writeFile(t, filepath.Join(wt, ".orc", "artifacts", "x"), "y")
+	writeFile(t, filepath.Join(wt, ".orc", "audit", "z"), "w")
+	if s := gitStatusPorcelain(t, wt); s != "" {
+		t.Errorf("artifacts/audit should be gitignored, got dirty:\n%s", s)
+	}
+}

--- a/internal/state/history.go
+++ b/internal/state/history.go
@@ -49,6 +49,13 @@ func LatestHistoryDir(artifactsDir string) (string, error) {
 	return "", nil
 }
 
+// CopyTree recursively copies src to dst (files, directories; symlinks skipped),
+// preserving file permission bits. Parent dirs of dst are created as needed.
+// Exported wrapper around the internal copyEntry used by ArchiveRun.
+func CopyTree(src, dst string) error {
+	return copyEntry(src, dst)
+}
+
 // copyEntry recursively copies src to dst.
 func copyEntry(src, dst string) error {
 	info, err := os.Lstat(src)


### PR DESCRIPTION
## Summary

Redesigns `orc eval` so its quality signal is **trustworthy**: the grader is held out from the workflow under test, the agent runs against a **clean** git stage, and grading is **separable** so a finished run can be re-graded against an edited rubric without re-running.

Closes #9 (no separation of agent-input vs held-out grader; check var-access; injected-prompt dirty tree; var-in-var expansion) and #8 (re-grade without re-run).

Design: `docs/superpowers/specs/2026-06-23-eval-redesign-design.md` · Plan: `docs/superpowers/plans/2026-06-23-eval-redesign.md`

## What changed

- **Held-out grader via a curation commit.** `orc eval` creates a worktree at the fixture `ref`, then makes one commit that: copies the case spec to `.orc/eval-spec/spec.md`, removes the **entire** `.orc/evals/` dir (the grader is never on the agent's stage), writes the **live** workflow/prompt files, and gitignores `.orc/artifacts/` + `.orc/audit/`. The worktree is therefore **git-clean** — workflow clean-tree guards pass (#9 P3). The grader is read from the **live** project at grade time, never from the worktree (#9 P1).
- **Eval-mode contract (opt-in).** orc sets `ORC_EVAL=1` and `ORC_SPEC_FILE=<abs path>`. A workflow whose ticket-fetch hits an external store (Jira, etc.) can branch on these to read the local spec; a self-contained workflow needs no change. orc neither requires nor enforces it.
- **Grader sees fixture vars, resolves from project root.** `check:`/judge run with `cwd = projectRoot` and receive fixture `vars` as both `KEY` and `ORC_KEY` (#9 P2), with var-in-var expansion in alphabetical key order (#9 P4).
- **`--regrade`.** `orc eval <case> --regrade` re-scores the latest saved run against the current rubric without re-running; `orc eval <case> --regrade <run-id>` targets a specific run (#8). (`--regrade` is a boolean flag; the run-id is a trailing positional — urfave/cli/v3 has no optional-value string flag.)
- **Two fingerprints.** History records a workflow fingerprint (config + prompts) and a per-case rubric fingerprint; `orc eval --report` shows both columns, so a score change from a workflow edit is distinguishable from one caused by a rubric edit.

## ⚠️ Breaking change — migration required

`spec:` is now a **required** field in `fixture.yaml`. Existing eval cases must add a `spec:` line naming the agent-visible spec file (e.g. `spec: spec.md`) and provide that file in the case dir. There is no fallback to "the spec lives in the ref" — this is a hard migration (the feature had no real-world users yet).

## Testing

- `make test` — all packages pass (incl. `internal/eval`, `internal/runner`).
- `make build` — clean; `orc eval --help` and `orc docs eval` reflect the new surface.
- New tests: stage build (clean tree / grader absent / live prompt / spec injected / artifacts gitignored), grader-sees-vars + var-in-var + project-root cwd, rubric fingerprint, `--regrade` run resolution.

## Docs

`orc docs eval`, README, and CLAUDE.md all updated.

## Review process

Implemented task-by-task (8 plan tasks + a doc-surface sweep), each with an independent per-task code review (spec compliance + quality); all came back clean. A whole-branch deep review (opus expert panel) runs after CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
